### PR TITLE
[M1.1][ORCH] add orchestrator & env loader; refine Binance client

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+FTM2 Orchestrator (minimal)
+- ENV 로딩 → BinanceClient 생성 → (옵션) REST 마크프라이스 폴러 시작
+- 10초 하트비트 로그
+- Ctrl+C 안전 종료
+"""
+from __future__ import annotations
+
+import os
+import time
+import signal
+import logging
+import threading
+from typing import List
+
+# 로컬 모듈
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+from ftm2.exchange.binance import BinanceClient
+
+log = logging.getLogger("ftm2.orch")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# [ANCHOR:ORCH]
+class Orchestrator:
+    def __init__(self) -> None:
+        self.env = load_env_chain()
+        self.mode = (os.getenv("MODE") or "testnet").lower()
+        self.symbols: List[str] = [s.strip() for s in (os.getenv("SYMBOLS") or "BTCUSDT,ETHUSDT").split(",") if s.strip()]
+        self.tf_exec = os.getenv("TF_EXEC") or "1m"
+        self.tf_signal = os.getenv("TF_SIGNAL") or "1m"
+
+        self.bus = StateBus()
+        self.cli = BinanceClient.from_env(order_active=False)
+
+        self._stop = threading.Event()
+        self._threads: List[threading.Thread] = []
+
+        # 부팅 요약
+        log.info("[BOOT_ENV_SUMMARY] MODE=%s, SYMBOLS=%s, TF_EXEC=%s, TF_SIGNAL=%s", self.mode, self.symbols, self.tf_exec, self.tf_signal)
+        for k in ("DB_PATH", "CONFIG_PATH", "PATCH_LOG"):
+            if os.getenv(k):
+                log.info("[BOOT_PATH] %s=%s", k, os.getenv(k))
+
+    # -------- optional: simple REST poller (mark price) ----------
+    def _price_poller(self, symbol: str, interval_s: float = 3.0) -> None:
+        while not self._stop.is_set():
+            r = self.cli.mark_price(symbol)
+            if r.get("ok"):
+                d = r["data"]
+                price = float(d.get("markPrice", 0.0))
+                ts = int(d.get("time") or int(time.time() * 1000))
+                self.bus.update_mark(symbol, price, ts)
+                log.debug("[PRICE_POLL] %s price=%s ts=%s", symbol, price, ts)
+            time.sleep(interval_s)
+
+    def start(self) -> None:
+        # 심볼별 마크프라이스 폴러 시작 (WS는 M1.3에서 대체)
+        for sym in self.symbols:
+            t = threading.Thread(target=self._price_poller, args=(sym,), name=f"poll:{sym}", daemon=True)
+            t.start()
+            self._threads.append(t)
+
+        # 하트비트 스레드
+        t = threading.Thread(target=self._heartbeat, name="heartbeat", daemon=True)
+        t.start()
+        self._threads.append(t)
+
+        # 시그널 핸들
+        try:
+            signal.signal(signal.SIGINT, self._signal_stop)
+            signal.signal(signal.SIGTERM, self._signal_stop)
+        except Exception:
+            pass
+
+    def _heartbeat(self, period_s: int = 10) -> None:
+        while not self._stop.is_set():
+            snap = self.bus.snapshot()
+            marks = snap["marks"]
+            lines = []
+            for s in self.symbols:
+                if s in marks:
+                    lines.append(f"{s}={marks[s]['price']}")
+            uptime = self.bus.uptime_s()
+            log.info("[HEARTBEAT] mode=%s uptime=%ss symbols=%d marks={%s}", self.mode, uptime, len(marks), ", ".join(lines))
+            time.sleep(period_s)
+
+    def _signal_stop(self, *_):
+        log.info("[SHUTDOWN] stop requested")
+        self.stop()
+
+    def stop(self) -> None:
+        if self._stop.is_set():
+            return
+        self._stop.set()
+        for t in list(self._threads):
+            if t.is_alive():
+                t.join(timeout=2.0)
+        log.info("[SHUTDOWN] orchestrator stopped")
+
+
+def run() -> None:
+    orch = Orchestrator()
+    orch.start()
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        orch.stop()
+
+
+if __name__ == "__main__":
+    run()

--- a/ftm2/core/env.py
+++ b/ftm2/core/env.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+간단 ENV 체인 로더
+- 우선순위: os.environ > token.env > .env
+- 파일이 없으면 무시. 값은 'KEY=VALUE' 형태만 인식.
+"""
+from __future__ import annotations
+import os
+from typing import Dict, Tuple
+
+# [ANCHOR:ENV_LOADER]
+def _parse_env_file(path: str) -> Dict[str, str]:
+    kv: Dict[str, str] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                kv[k] = v
+    except FileNotFoundError:
+        pass
+    return kv
+
+def load_env_chain(paths: Tuple[str, ...] = ("token.env", ".env")) -> Dict[str, str]:
+    # 1) 시작은 현재 OS 환경을 복사
+    env: Dict[str, str] = dict(os.environ)
+
+    # 2) token.env → .env 순서로, **존재하지 않는 키만** 주입
+    for p in paths:
+        kv = _parse_env_file(p)
+        for k, v in kv.items():
+            if k not in env or env.get(k) in (None, ""):
+                os.environ.setdefault(k, v)
+                env.setdefault(k, v)
+
+    return env

--- a/ftm2/core/state.py
+++ b/ftm2/core/state.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+스레드-세이프 전역 StateBus
+- marks: {symbol: {"price": float, "time": int}}
+- klines: {(symbol, interval): last_bar_dict}
+- positions: [ {..}, ... ]
+- account: {...}
+"""
+from __future__ import annotations
+import threading
+import time
+from typing import Dict, Tuple, Any, List
+
+# [ANCHOR:STATE_BUS]
+class StateBus:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._marks: Dict[str, Dict[str, Any]] = {}
+        self._klines: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._positions: List[Dict[str, Any]] = []
+        self._account: Dict[str, Any] = {}
+        self._boot_ts = int(time.time() * 1000)
+
+    # --- updates
+    def update_mark(self, symbol: str, price: float, ts_ms: int) -> None:
+        with self._lock:
+            self._marks[symbol] = {"price": float(price), "time": int(ts_ms)}
+
+    def update_kline(self, symbol: str, interval: str, bar: Dict[str, Any]) -> None:
+        with self._lock:
+            self._klines[(symbol, interval)] = dict(bar)
+
+    def set_positions(self, positions: List[Dict[str, Any]]) -> None:
+        with self._lock:
+            self._positions = list(positions)
+
+    def set_account(self, account: Dict[str, Any]) -> None:
+        with self._lock:
+            self._account = dict(account)
+
+    # --- reads
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "marks": dict(self._marks),
+                "klines": dict(self._klines),
+                "positions": list(self._positions),
+                "account": dict(self._account),
+                "ts": int(time.time() * 1000),
+            }
+
+    def uptime_s(self) -> int:
+        return int(time.time() - (self._boot_ts / 1000.0))

--- a/ftm2/tests/__init__.py
+++ b/ftm2/tests/__init__.py
@@ -1,0 +1,1 @@
+# test package

--- a/ftm2/tests/test_env_state.py
+++ b/ftm2/tests/test_env_state.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+
+
+def test_load_env_chain(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.env"
+    token_file.write_text("KEY1=token\nKEY2=token\n")
+    env_file = tmp_path / ".env"
+    env_file.write_text("KEY2=env\nKEY3=env\n")
+
+    monkeypatch.setenv("KEY1", "os")
+
+    env = load_env_chain(paths=(str(token_file), str(env_file)))
+    assert env["KEY1"] == "os"
+    assert env["KEY2"] == "token"
+    assert env["KEY3"] == "env"
+
+
+def test_state_bus_snapshot():
+    bus = StateBus()
+    bus.update_mark("BTCUSDT", 100.0, 123)
+    bus.update_kline("BTCUSDT", "1m", {"o":1})
+    bus.set_positions([{"symbol": "BTCUSDT"}])
+    bus.set_account({"balance": 1})
+    snap = bus.snapshot()
+    assert snap["marks"]["BTCUSDT"]["price"] == 100.0
+    assert snap["klines"][("BTCUSDT", "1m")]["o"] == 1
+    assert snap["positions"][0]["symbol"] == "BTCUSDT"
+    assert snap["account"]["balance"] == 1
+    assert isinstance(snap["ts"], int)

--- a/patch.txt
+++ b/patch.txt
@@ -8,3 +8,6 @@
 # - feat(state): 전역 스냅샷 버스 규격 확정
 # - feat(discord): /mode /auto /close 명령 스펙 고정
 # - feat(risk): ATR-unit 파라미터 세트 확정(R%, day-cut, corr-cap)
+2025-09-03 v0.1.0
+- feat(connector): add Binance USDⓈ-M client stubs with testnet/live toggle (REST/WS)
+- feat(orch): add minimal orchestrator & state bus with env loader, heartbeat, and REST mark-price poller


### PR DESCRIPTION
## Summary
- implement env-chain loader and thread-safe StateBus for global snapshots
- add minimal orchestrator with mark-price REST poller and heartbeat logging
- clean up Binance client ping response and unused imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7c09eac0c832dad14172208213d3c