### PR TITLE
[M1.3][STREAMS] add StreamManager for Binance WebSocket feeds

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+FTM2 Orchestrator (minimal)
+- ENV 로딩 → BinanceClient 생성 → WS 스트림(StreamManager) 시작
+- 10초 하트비트 로그
+- Ctrl+C 안전 종료
+"""
+from __future__ import annotations
+
+import os
+import time
+import signal
+import logging
+import threading
+from typing import List
+
+# 로컬 모듈
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+from ftm2.exchange.binance import BinanceClient
+from ftm2.data.streams import StreamManager
+
+log = logging.getLogger("ftm2.orch")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# [ANCHOR:ORCH]
+class Orchestrator:
+    def __init__(self) -> None:
+        self.env = load_env_chain()
+        self.mode = (os.getenv("MODE") or "testnet").lower()
+        self.symbols: List[str] = [s.strip() for s in (os.getenv("SYMBOLS") or "BTCUSDT,ETHUSDT").split(",") if s.strip()]
+        self.tf_exec = os.getenv("TF_EXEC") or "1m"
+        self.kline_intervals = [s.strip() for s in (os.getenv("TF_SIGNAL") or "5m,15m,1h,4h").split(",") if s.strip()]
+
+        self.bus = StateBus()
+        self.cli = BinanceClient.from_env(order_active=False)
+        self.streams = StreamManager(self.cli, self.bus, self.symbols, self.kline_intervals, use_mark=True, use_user=True)
+
+        self._stop = threading.Event()
+        self._threads: List[threading.Thread] = []
+
+        # 부팅 요약
+        log.info("[BOOT_ENV_SUMMARY] MODE=%s, SYMBOLS=%s, TF_EXEC=%s, TF_SIGNAL=%s", self.mode, self.symbols, self.tf_exec, self.kline_intervals)
+        for k in ("DB_PATH", "CONFIG_PATH", "PATCH_LOG"):
+            if os.getenv(k):
+                log.info("[BOOT_PATH] %s=%s", k, os.getenv(k))
+
+    # -------- optional: simple REST poller (mark price) ----------
+    def _price_poller(self, symbol: str, interval_s: float = 3.0) -> None:
+        while not self._stop.is_set():
+            r = self.cli.mark_price(symbol)
+            if r.get("ok"):
+                d = r["data"]
+                price = float(d.get("markPrice", 0.0))
+                ts = int(d.get("time") or int(time.time() * 1000))
+                self.bus.update_mark(symbol, price, ts)
+                log.debug("[PRICE_POLL] %s price=%s ts=%s", symbol, price, ts)
+            time.sleep(interval_s)
+
+    def start(self) -> None:
+        # 심볼별 마크프라이스 폴러는 M1.1 임시 → WS로 대체
+        # for sym in self.symbols:
+        #     t = threading.Thread(target=self._price_poller, args=(sym,), name=f"poll:{sym}", daemon=True)
+        #     t.start()
+        #     self._threads.append(t)
+
+        # WS 스트림 시작
+        self.streams.start()
+
+        # 하트비트 스레드
+        t = threading.Thread(target=self._heartbeat, name="heartbeat", daemon=True)
+        t.start()
+        self._threads.append(t)
+
+        # 시그널 핸들
+        try:
+            signal.signal(signal.SIGINT, self._signal_stop)
+            signal.signal(signal.SIGTERM, self._signal_stop)
+        except Exception:
+            pass
+
+    def _heartbeat(self, period_s: int = 10) -> None:
+        while not self._stop.is_set():
+            snap = self.bus.snapshot()
+            marks = snap["marks"]
+            lines = []
+            for s in self.symbols:
+                if s in marks:
+                    lines.append(f"{s}={marks[s]['price']}")
+            uptime = self.bus.uptime_s()
+            log.info("[HEARTBEAT] mode=%s uptime=%ss symbols=%d marks={%s}", self.mode, uptime, len(marks), ", ".join(lines))
+            time.sleep(period_s)
+
+    def _signal_stop(self, *_):
+        log.info("[SHUTDOWN] stop requested")
+        self.stop()
+
+    def stop(self) -> None:
+        if self._stop.is_set():
+            return
+        self._stop.set()
+        try:
+            self.streams.stop()
+        except Exception:
+            pass
+        for t in list(self._threads):
+            if t.is_alive():
+                t.join(timeout=2.0)
+        log.info("[SHUTDOWN] orchestrator stopped")
+
+
+def run() -> None:
+    orch = Orchestrator()
+    orch.start()
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        orch.stop()
+
+
+if __name__ == "__main__":
+    run()

--- a/ftm2/core/env.py
+++ b/ftm2/core/env.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+간단 ENV 체인 로더
+- 우선순위: os.environ > token.env > .env
+- 파일이 없으면 무시. 값은 'KEY=VALUE' 형태만 인식.
+"""
+from __future__ import annotations
+import os
+from typing import Dict, Tuple
+
+# [ANCHOR:ENV_LOADER]
+def _parse_env_file(path: str) -> Dict[str, str]:
+    kv: Dict[str, str] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                kv[k] = v
+    except FileNotFoundError:
+        pass
+    return kv
+
+def load_env_chain(paths: Tuple[str, ...] = ("token.env", ".env")) -> Dict[str, str]:
+    # 1) 시작은 현재 OS 환경을 복사
+    env: Dict[str, str] = dict(os.environ)
+
+    # 2) token.env → .env 순서로, **존재하지 않는 키만** 주입
+    for p in paths:
+        kv = _parse_env_file(p)
+        for k, v in kv.items():
+            if k not in env or env.get(k) in (None, ""):
+                os.environ.setdefault(k, v)
+                env.setdefault(k, v)
+
+    return env

--- a/ftm2/core/state.py
+++ b/ftm2/core/state.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+스레드-세이프 전역 StateBus
+- marks: {symbol: {"price": float, "time": int}}
+- klines: {(symbol, interval): last_bar_dict}
+- positions: [ {..}, ... ]
+- account: {...}
+"""
+from __future__ import annotations
+import threading
+import time
+from typing import Dict, Tuple, Any, List
+
+# [ANCHOR:STATE_BUS]
+class StateBus:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._marks: Dict[str, Dict[str, Any]] = {}
+        self._klines: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._positions: List[Dict[str, Any]] = []
+        self._account: Dict[str, Any] = {}
+        self._boot_ts = int(time.time() * 1000)
+
+    # --- updates
+    def update_mark(self, symbol: str, price: float, ts_ms: int) -> None:
+        with self._lock:
+            self._marks[symbol] = {"price": float(price), "time": int(ts_ms)}
+
+    def update_kline(self, symbol: str, interval: str, bar: Dict[str, Any]) -> None:
+        with self._lock:
+            self._klines[(symbol, interval)] = dict(bar)
+
+    def set_positions(self, positions: List[Dict[str, Any]]) -> None:
+        with self._lock:
+            self._positions = list(positions)
+
+    def set_account(self, account: Dict[str, Any]) -> None:
+        with self._lock:
+            self._account = dict(account)
+
+    # --- reads
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "marks": dict(self._marks),
+                "klines": dict(self._klines),
+                "positions": list(self._positions),
+                "account": dict(self._account),
+                "ts": int(time.time() * 1000),
+            }
+
+    def uptime_s(self) -> int:
+        return int(time.time() - (self._boot_ts / 1000.0))

--- a/ftm2/data/streams.py
+++ b/ftm2/data/streams.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""
+Market Streams Manager
+- kline / markPrice / user stream(listenKey)
+- BinanceClient.subscribe_* 핸들을 관리하고, 수신 데이터를 StateBus 에 반영
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import List, Dict, Any, Optional
+
+from ftm2.exchange.binance import BinanceClient, WSHandle
+from ftm2.core.state import StateBus
+
+log = logging.getLogger("ftm2.streams")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# [ANCHOR:STREAMS]
+class StreamManager:
+    def __init__(
+        self,
+        client: BinanceClient,
+        bus: StateBus,
+        symbols: List[str],
+        kline_intervals: List[str],
+        *,
+        use_mark: bool = True,
+        use_user: bool = True,
+    ) -> None:
+        self.cli = client
+        self.bus = bus
+        self.symbols = symbols
+        self.kline_intervals = kline_intervals
+        self.use_mark = use_mark
+        self.use_user = use_user
+
+        self._handles: List[WSHandle] = []
+        self._stop = threading.Event()
+
+        # user stream
+        self._listen_key: Optional[str] = None
+        self._keepalive_th: Optional[threading.Thread] = None
+
+    # ---------------------- public API ----------------------
+    def start(self) -> None:
+        # kline
+        for sym in self.symbols:
+            for itv in self.kline_intervals:
+                h = self.cli.subscribe_kline(sym, itv, self._on_kline)
+                if h.error:
+                    log.warning("[WS HANDLE_ERR] kline %s %s %s", sym, itv, h.error)
+                self._handles.append(h)
+        # mark price
+        if self.use_mark:
+            for sym in self.symbols:
+                h = self.cli.subscribe_mark_price(sym, self._on_mark)
+                if h.error:
+                    log.warning("[WS HANDLE_ERR] markPrice %s %s", sym, h.error)
+                self._handles.append(h)
+
+        log.info("[WS START] kline=%s mark=%s symbols=%d", 
+                 ",".join(self.kline_intervals), self.use_mark, len(self.symbols))
+
+        # user stream
+        if self.use_user and self.cli.key and self.cli.secret:
+            r = self.cli.start_user_stream()
+            if r.get("ok"):
+                self._listen_key = r["data"].get("listenKey")
+                if self._listen_key:
+                    h = self.cli.subscribe_user(self._listen_key, self._on_user)
+                    if h.error:
+                        log.warning("[WS HANDLE_ERR] user %s", h.error)
+                    self._handles.append(h)
+                    log.info("[LISTENKEY] started key=%s", self._listen_key)
+
+                    # keepalive 25분 주기
+                    self._keepalive_th = threading.Thread(target=self._keepalive_loop,
+                                                          name="listenKey-keepalive", daemon=True)
+                    self._keepalive_th.start()
+            else:
+                log.warning("[USER_STREAM] cannot start: %s", r.get("error"))
+        else:
+            log.info("[USER_STREAM] disabled (no key/secret or use_user=False)")
+
+    def stop(self) -> None:
+        self._stop.set()
+        # close user stream first
+        if self._listen_key:
+            try:
+                self.cli.close_user_stream(self._listen_key)
+            except Exception:
+                pass
+        # stop ws handles
+        for h in list(self._handles):
+            try:
+                h.stop(timeout=2.0)
+            except Exception:
+                pass
+        self._handles.clear()
+
+        if self._keepalive_th and self._keepalive_th.is_alive():
+            self._keepalive_th.join(timeout=2.0)
+        log.info("[WS STOPPED] all streams closed")
+
+    # ---------------------- callbacks ----------------------
+    def _on_kline(self, msg: Dict[str, Any]) -> None:
+        """
+        msg 예(요약):
+        {
+          "e":"kline","E":1690000000000,"s":"BTCUSDT",
+          "k":{"t":..., "T":..., "s":"BTCUSDT","i":"1m","o":"...","h":"...","l":"...","c":"...","v":"...", "x":false, ...}
+        }
+        """
+        try:
+            if (msg.get("e") or "").lower() != "kline":
+                return
+            k = msg.get("k") or {}
+            sym = (k.get("s") or msg.get("s") or "").upper()
+            itv = k.get("i") or ""
+            bar = {
+                "t": int(k.get("t", 0)),
+                "T": int(k.get("T", 0)),
+                "o": float(k.get("o", 0.0)),
+                "h": float(k.get("h", 0.0)),
+                "l": float(k.get("l", 0.0)),
+                "c": float(k.get("c", 0.0)),
+                "v": float(k.get("v", 0.0)),
+                "x": bool(k.get("x", False)),
+            }
+            self.bus.update_kline(sym, itv, bar)
+            log.debug("[WS KLINE] %s %s close=%s", sym, itv, bar["x"])
+        except Exception as e:
+            log.exception("kline cb err: %s", e)
+
+    def _on_mark(self, msg: Dict[str, Any]) -> None:
+        """
+        futures markPrice stream:
+        {"e":"markPriceUpdate","E":..., "s":"BTCUSDT","p":"<mark>","r":"<est funding>","T":..., ...}
+        """
+        try:
+            sym = (msg.get("s") or "").upper()
+            if not sym:
+                return
+            p = msg.get("p") or msg.get("markPrice") or 0.0
+            ts = int(msg.get("E") or msg.get("T") or 0)
+            self.bus.update_mark(sym, float(p), ts)
+            log.debug("[WS MARK] %s price=%s ts=%s", sym, p, ts)
+        except Exception as e:
+            log.exception("mark cb err: %s", e)
+
+    def _on_user(self, msg: Dict[str, Any]) -> None:
+        """
+        futures user data (요약):
+        - ACCOUNT_UPDATE: {"e":"ACCOUNT_UPDATE","a":{"B":[... balances ...], "P":[... positions ...]}}
+        - ORDER_TRADE_UPDATE: {"e":"ORDER_TRADE_UPDATE","o":{...}}
+        """
+        try:
+            evt = (msg.get("e") or "").upper()
+            if evt == "ACCOUNT_UPDATE":
+                a = msg.get("a") or {}
+                # positions array → {symbol: {...}} 로 단순 매핑
+                pos_map: Dict[str, Dict[str, Any]] = {}
+                for p in a.get("P", []):
+                    sym = (p.get("s") or "").upper()
+                    if not sym:
+                        continue
+                    pos_map[sym] = {
+                        "symbol": sym,
+                        "pa": float(p.get("pa", 0.0)),
+                        "ep": float(p.get("ep", 0.0)),
+                        "up": float(p.get("up", 0.0)),
+                        "mt": p.get("mt"),
+                    }
+                if pos_map:
+                    self.bus.set_positions(pos_map)
+            elif evt == "ORDER_TRADE_UPDATE":
+                o = msg.get("o") or {}
+                log.info("[USER_STREAM][OTU] %s %s %s %s", o.get("s"), o.get("S"), o.get("X"), o.get("ap"))
+        except Exception as e:
+            log.exception("user cb err: %s", e)
+
+    # ---------------------- internals ----------------------
+    def _keepalive_loop(self, period_s: int = 1500) -> None:
+        """
+        listenKey keepalive. 기본 25분(1500s).
+        실패 시 새 키로 재시작을 시도한다.
+        """
+        while not self._stop.is_set():
+            time.sleep(period_s)
+            if self._stop.is_set():
+                break
+            if not self._listen_key:
+                continue
+            r = self.cli.keepalive_user_stream(self._listen_key)
+            if r.get("ok"):
+                log.debug("[KEEPALIVE] ok key=%s", self._listen_key)
+            else:
+                log.warning("[KEEPALIVE] failed %s → try re-create", r.get("error"))
+                # 재생성
+                r2 = self.cli.start_user_stream()
+                if r2.get("ok"):
+                    self._listen_key = r2["data"].get("listenKey")
+                    log.info("[LISTENKEY] rotated key=%s", self._listen_key)
+                else:
+                    log.error("[LISTENKEY] rotate failed: %s", r2.get("error"))
+

--- a/ftm2/tests/__init__.py
+++ b/ftm2/tests/__init__.py
@@ -1,0 +1,1 @@
+# test package

--- a/ftm2/tests/test_env_state.py
+++ b/ftm2/tests/test_env_state.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+
+
+def test_load_env_chain(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.env"
+    token_file.write_text("KEY1=token\nKEY2=token\n")
+    env_file = tmp_path / ".env"
+    env_file.write_text("KEY2=env\nKEY3=env\n")
+
+    monkeypatch.setenv("KEY1", "os")
+
+    env = load_env_chain(paths=(str(token_file), str(env_file)))
+    assert env["KEY1"] == "os"
+    assert env["KEY2"] == "token"
+    assert env["KEY3"] == "env"
+
+
+def test_state_bus_snapshot():
+    bus = StateBus()
+    bus.update_mark("BTCUSDT", 100.0, 123)
+    bus.update_kline("BTCUSDT", "1m", {"o":1})
+    bus.set_positions([{"symbol": "BTCUSDT"}])
+    bus.set_account({"balance": 1})
+    snap = bus.snapshot()
+    assert snap["marks"]["BTCUSDT"]["price"] == 100.0
+    assert snap["klines"][("BTCUSDT", "1m")]["o"] == 1
+    assert snap["positions"][0]["symbol"] == "BTCUSDT"
+    assert snap["account"]["balance"] == 1
+    assert isinstance(snap["ts"], int)

--- a/patch.txt
+++ b/patch.txt
@@ -8,3 +8,7 @@
 # - feat(state): 전역 스냅샷 버스 규격 확정
 # - feat(discord): /mode /auto /close 명령 스펙 고정
 # - feat(risk): ATR-unit 파라미터 세트 확정(R%, day-cut, corr-cap)
+2025-09-03 v0.1.0
+- feat(connector): add Binance USDⓈ-M client stubs with testnet/live toggle (REST/WS)
+- feat(orch): add minimal orchestrator & state bus with env loader, heartbeat, and REST mark-price poller
+- feat(streams): add StreamManager for kline/markPrice/user streams and StateBus updates


### PR DESCRIPTION
## Summary
- manage Binance WebSocket kline, mark-price, and user data streams through a centralized StreamManager that updates the global StateBus
- wire StreamManager into the orchestrator, parsing `TF_SIGNAL` for intervals and replacing REST polling with WS streams
- record stream-manager feature in `patch.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c09eac0c832dad14172208213d3c