### PR TITLE
[M1.5][DISCORD] add Discord bot skeleton with Korean UI

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""
+FTM2 Orchestrator (minimal)
+- ENV 로딩 → BinanceClient 생성 → WS 스트림(StreamManager) 시작
+- 10초 하트비트 로그
+- Ctrl+C 안전 종료
+"""
+from __future__ import annotations
+
+import os
+import time
+import signal
+import logging
+import threading
+from typing import List
+
+# 로컬 모듈
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+from ftm2.exchange.binance import BinanceClient
+from ftm2.data.streams import StreamManager
+try:
+    from ftm2.discord_bot.bot import run_discord_bot
+except Exception:  # pragma: no cover
+    from discord_bot.bot import run_discord_bot  # type: ignore
+
+log = logging.getLogger("ftm2.orch")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# [ANCHOR:ORCH]
+class Orchestrator:
+    def __init__(self) -> None:
+        self.env = load_env_chain()
+        self.mode = (os.getenv("MODE") or "testnet").lower()
+        self.symbols: List[str] = [s.strip() for s in (os.getenv("SYMBOLS") or "BTCUSDT,ETHUSDT").split(",") if s.strip()]
+        self.tf_exec = os.getenv("TF_EXEC") or "1m"
+        self.kline_intervals = [s.strip() for s in (os.getenv("TF_SIGNAL") or "5m,15m,1h,4h").split(",") if s.strip()]
+
+        self.bus = StateBus()
+        self.cli = BinanceClient.from_env(order_active=False)
+        self.streams = StreamManager(self.cli, self.bus, self.symbols, self.kline_intervals, use_mark=True, use_user=True)
+
+        self._stop = threading.Event()
+        self._threads: List[threading.Thread] = []
+
+        # 부팅 요약
+        log.info("[BOOT_ENV_SUMMARY] MODE=%s, SYMBOLS=%s, TF_EXEC=%s, TF_SIGNAL=%s", self.mode, self.symbols, self.tf_exec, self.kline_intervals)
+        for k in ("DB_PATH", "CONFIG_PATH", "PATCH_LOG"):
+            if os.getenv(k):
+                log.info("[BOOT_PATH] %s=%s", k, os.getenv(k))
+
+    # -------- optional: simple REST poller (mark price) ----------
+    def _price_poller(self, symbol: str, interval_s: float = 3.0) -> None:
+        while not self._stop.is_set():
+            r = self.cli.mark_price(symbol)
+            if r.get("ok"):
+                d = r["data"]
+                price = float(d.get("markPrice", 0.0))
+                ts = int(d.get("time") or int(time.time() * 1000))
+                self.bus.update_mark(symbol, price, ts)
+                log.debug("[PRICE_POLL] %s price=%s ts=%s", symbol, price, ts)
+            time.sleep(interval_s)
+
+    def start(self) -> None:
+        # 심볼별 마크프라이스 폴러는 M1.1 임시 → WS로 대체
+        # for sym in self.symbols:
+        #     t = threading.Thread(target=self._price_poller, args=(sym,), name=f"poll:{sym}", daemon=True)
+        #     t.start()
+        #     self._threads.append(t)
+
+        # WS 스트림 시작
+        self.streams.start()
+
+        # 하트비트 스레드
+        t = threading.Thread(target=self._heartbeat, name="heartbeat", daemon=True)
+        t.start()
+        self._threads.append(t)
+
+        # Discord 봇 (토큰 없으면 내부에서 자동 비활성 로그 후 종료)
+        dt = threading.Thread(target=run_discord_bot, args=(self.bus,), name="discord-bot", daemon=True)
+        dt.start()
+        self._threads.append(dt)
+
+        # 시그널 핸들
+        try:
+            signal.signal(signal.SIGINT, self._signal_stop)
+            signal.signal(signal.SIGTERM, self._signal_stop)
+        except Exception:
+            pass
+
+    def _heartbeat(self, period_s: int = 10) -> None:
+        while not self._stop.is_set():
+            snap = self.bus.snapshot()
+            marks = snap["marks"]
+            lines = []
+            for s in self.symbols:
+                if s in marks:
+                    lines.append(f"{s}={marks[s]['price']}")
+            uptime = self.bus.uptime_s()
+            log.info("[HEARTBEAT] mode=%s uptime=%ss symbols=%d marks={%s}", self.mode, uptime, len(marks), ", ".join(lines))
+            time.sleep(period_s)
+
+    def _signal_stop(self, *_):
+        log.info("[SHUTDOWN] stop requested")
+        self.stop()
+
+    def stop(self) -> None:
+        if self._stop.is_set():
+            return
+        self._stop.set()
+        try:
+            self.streams.stop()
+        except Exception:
+            pass
+        for t in list(self._threads):
+            if t.is_alive():
+                t.join(timeout=2.0)
+        log.info("[SHUTDOWN] orchestrator stopped")
+
+
+def run() -> None:
+    orch = Orchestrator()
+    orch.start()
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        orch.stop()
+
+
+if __name__ == "__main__":
+    run()

--- a/ftm2/core/env.py
+++ b/ftm2/core/env.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+간단 ENV 체인 로더
+- 우선순위: os.environ > token.env > .env
+- 파일이 없으면 무시. 값은 'KEY=VALUE' 형태만 인식.
+"""
+from __future__ import annotations
+import os
+from typing import Dict, Tuple
+
+# [ANCHOR:ENV_LOADER]
+def _parse_env_file(path: str) -> Dict[str, str]:
+    kv: Dict[str, str] = {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for raw in f:
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                kv[k] = v
+    except FileNotFoundError:
+        pass
+    return kv
+
+def load_env_chain(paths: Tuple[str, ...] = ("token.env", ".env")) -> Dict[str, str]:
+    # 1) 시작은 현재 OS 환경을 복사
+    env: Dict[str, str] = dict(os.environ)
+
+    # 2) token.env → .env 순서로, **존재하지 않는 키만** 주입
+    for p in paths:
+        kv = _parse_env_file(p)
+        for k, v in kv.items():
+            if k not in env or env.get(k) in (None, ""):
+                os.environ.setdefault(k, v)
+                env.setdefault(k, v)
+
+    return env

--- a/ftm2/core/state.py
+++ b/ftm2/core/state.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""
+스레드-세이프 전역 StateBus
+- marks: {symbol: {"price": float, "time": int}}
+- klines: {(symbol, interval): last_bar_dict}
+- positions: [ {..}, ... ]
+- account: {...}
+"""
+from __future__ import annotations
+import threading
+import time
+from typing import Dict, Tuple, Any, List
+
+# [ANCHOR:STATE_BUS]
+class StateBus:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._marks: Dict[str, Dict[str, Any]] = {}
+        self._klines: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._positions: List[Dict[str, Any]] = []
+        self._account: Dict[str, Any] = {}
+        self._boot_ts = int(time.time() * 1000)
+
+    # --- updates
+    def update_mark(self, symbol: str, price: float, ts_ms: int) -> None:
+        with self._lock:
+            self._marks[symbol] = {"price": float(price), "time": int(ts_ms)}
+
+    def update_kline(self, symbol: str, interval: str, bar: Dict[str, Any]) -> None:
+        with self._lock:
+            self._klines[(symbol, interval)] = dict(bar)
+
+    def set_positions(self, positions: List[Dict[str, Any]]) -> None:
+        with self._lock:
+            self._positions = list(positions)
+
+    def set_account(self, account: Dict[str, Any]) -> None:
+        with self._lock:
+            self._account = dict(account)
+
+    # --- reads
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "marks": dict(self._marks),
+                "klines": dict(self._klines),
+                "positions": list(self._positions),
+                "account": dict(self._account),
+                "ts": int(time.time() * 1000),
+            }
+
+    def uptime_s(self) -> int:
+        return int(time.time() - (self._boot_ts / 1000.0))

--- a/ftm2/data/streams.py
+++ b/ftm2/data/streams.py
@@ -1,0 +1,209 @@
+# -*- coding: utf-8 -*-
+"""
+Market Streams Manager
+- kline / markPrice / user stream(listenKey)
+- BinanceClient.subscribe_* 핸들을 관리하고, 수신 데이터를 StateBus 에 반영
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import List, Dict, Any, Optional
+
+from ftm2.exchange.binance import BinanceClient, WSHandle
+from ftm2.core.state import StateBus
+
+log = logging.getLogger("ftm2.streams")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+# [ANCHOR:STREAMS]
+class StreamManager:
+    def __init__(
+        self,
+        client: BinanceClient,
+        bus: StateBus,
+        symbols: List[str],
+        kline_intervals: List[str],
+        *,
+        use_mark: bool = True,
+        use_user: bool = True,
+    ) -> None:
+        self.cli = client
+        self.bus = bus
+        self.symbols = symbols
+        self.kline_intervals = kline_intervals
+        self.use_mark = use_mark
+        self.use_user = use_user
+
+        self._handles: List[WSHandle] = []
+        self._stop = threading.Event()
+
+        # user stream
+        self._listen_key: Optional[str] = None
+        self._keepalive_th: Optional[threading.Thread] = None
+
+    # ---------------------- public API ----------------------
+    def start(self) -> None:
+        # kline
+        for sym in self.symbols:
+            for itv in self.kline_intervals:
+                h = self.cli.subscribe_kline(sym, itv, self._on_kline)
+                if h.error:
+                    log.warning("[WS HANDLE_ERR] kline %s %s %s", sym, itv, h.error)
+                self._handles.append(h)
+        # mark price
+        if self.use_mark:
+            for sym in self.symbols:
+                h = self.cli.subscribe_mark_price(sym, self._on_mark)
+                if h.error:
+                    log.warning("[WS HANDLE_ERR] markPrice %s %s", sym, h.error)
+                self._handles.append(h)
+
+        log.info("[WS START] kline=%s mark=%s symbols=%d", 
+                 ",".join(self.kline_intervals), self.use_mark, len(self.symbols))
+
+        # user stream
+        if self.use_user and self.cli.key and self.cli.secret:
+            r = self.cli.start_user_stream()
+            if r.get("ok"):
+                self._listen_key = r["data"].get("listenKey")
+                if self._listen_key:
+                    h = self.cli.subscribe_user(self._listen_key, self._on_user)
+                    if h.error:
+                        log.warning("[WS HANDLE_ERR] user %s", h.error)
+                    self._handles.append(h)
+                    log.info("[LISTENKEY] started key=%s", self._listen_key)
+
+                    # keepalive 25분 주기
+                    self._keepalive_th = threading.Thread(target=self._keepalive_loop,
+                                                          name="listenKey-keepalive", daemon=True)
+                    self._keepalive_th.start()
+            else:
+                log.warning("[USER_STREAM] cannot start: %s", r.get("error"))
+        else:
+            log.info("[USER_STREAM] disabled (no key/secret or use_user=False)")
+
+    def stop(self) -> None:
+        self._stop.set()
+        # close user stream first
+        if self._listen_key:
+            try:
+                self.cli.close_user_stream(self._listen_key)
+            except Exception:
+                pass
+        # stop ws handles
+        for h in list(self._handles):
+            try:
+                h.stop(timeout=2.0)
+            except Exception:
+                pass
+        self._handles.clear()
+
+        if self._keepalive_th and self._keepalive_th.is_alive():
+            self._keepalive_th.join(timeout=2.0)
+        log.info("[WS STOPPED] all streams closed")
+
+    # ---------------------- callbacks ----------------------
+    def _on_kline(self, msg: Dict[str, Any]) -> None:
+        """
+        msg 예(요약):
+        {
+          "e":"kline","E":1690000000000,"s":"BTCUSDT",
+          "k":{"t":..., "T":..., "s":"BTCUSDT","i":"1m","o":"...","h":"...","l":"...","c":"...","v":"...", "x":false, ...}
+        }
+        """
+        try:
+            if (msg.get("e") or "").lower() != "kline":
+                return
+            k = msg.get("k") or {}
+            sym = (k.get("s") or msg.get("s") or "").upper()
+            itv = k.get("i") or ""
+            bar = {
+                "t": int(k.get("t", 0)),
+                "T": int(k.get("T", 0)),
+                "o": float(k.get("o", 0.0)),
+                "h": float(k.get("h", 0.0)),
+                "l": float(k.get("l", 0.0)),
+                "c": float(k.get("c", 0.0)),
+                "v": float(k.get("v", 0.0)),
+                "x": bool(k.get("x", False)),
+            }
+            self.bus.update_kline(sym, itv, bar)
+            log.debug("[WS KLINE] %s %s close=%s", sym, itv, bar["x"])
+        except Exception as e:
+            log.exception("kline cb err: %s", e)
+
+    def _on_mark(self, msg: Dict[str, Any]) -> None:
+        """
+        futures markPrice stream:
+        {"e":"markPriceUpdate","E":..., "s":"BTCUSDT","p":"<mark>","r":"<est funding>","T":..., ...}
+        """
+        try:
+            sym = (msg.get("s") or "").upper()
+            if not sym:
+                return
+            p = msg.get("p") or msg.get("markPrice") or 0.0
+            ts = int(msg.get("E") or msg.get("T") or 0)
+            self.bus.update_mark(sym, float(p), ts)
+            log.debug("[WS MARK] %s price=%s ts=%s", sym, p, ts)
+        except Exception as e:
+            log.exception("mark cb err: %s", e)
+
+    def _on_user(self, msg: Dict[str, Any]) -> None:
+        """
+        futures user data (요약):
+        - ACCOUNT_UPDATE: {"e":"ACCOUNT_UPDATE","a":{"B":[... balances ...], "P":[... positions ...]}}
+        - ORDER_TRADE_UPDATE: {"e":"ORDER_TRADE_UPDATE","o":{...}}
+        """
+        try:
+            evt = (msg.get("e") or "").upper()
+            if evt == "ACCOUNT_UPDATE":
+                a = msg.get("a") or {}
+                # positions array → {symbol: {...}} 로 단순 매핑
+                pos_map: Dict[str, Dict[str, Any]] = {}
+                for p in a.get("P", []):
+                    sym = (p.get("s") or "").upper()
+                    if not sym:
+                        continue
+                    pos_map[sym] = {
+                        "symbol": sym,
+                        "pa": float(p.get("pa", 0.0)),
+                        "ep": float(p.get("ep", 0.0)),
+                        "up": float(p.get("up", 0.0)),
+                        "mt": p.get("mt"),
+                    }
+                if pos_map:
+                    self.bus.set_positions(pos_map)
+            elif evt == "ORDER_TRADE_UPDATE":
+                o = msg.get("o") or {}
+                log.info("[USER_STREAM][OTU] %s %s %s %s", o.get("s"), o.get("S"), o.get("X"), o.get("ap"))
+        except Exception as e:
+            log.exception("user cb err: %s", e)
+
+    # ---------------------- internals ----------------------
+    def _keepalive_loop(self, period_s: int = 1500) -> None:
+        """
+        listenKey keepalive. 기본 25분(1500s).
+        실패 시 새 키로 재시작을 시도한다.
+        """
+        while not self._stop.is_set():
+            time.sleep(period_s)
+            if self._stop.is_set():
+                break
+            if not self._listen_key:
+                continue
+            r = self.cli.keepalive_user_stream(self._listen_key)
+            if r.get("ok"):
+                log.debug("[KEEPALIVE] ok key=%s", self._listen_key)
+            else:
+                log.warning("[KEEPALIVE] failed %s → try re-create", r.get("error"))
+                # 재생성
+                r2 = self.cli.start_user_stream()
+                if r2.get("ok"):
+                    self._listen_key = r2["data"].get("listenKey")
+                    log.info("[LISTENKEY] rotated key=%s", self._listen_key)
+                else:
+                    log.error("[LISTENKEY] rotate failed: %s", r2.get("error"))
+

--- a/ftm2/discord_bot/__init__.py
+++ b/ftm2/discord_bot/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Discord bot package."""

--- a/ftm2/discord_bot/bot.py
+++ b/ftm2/discord_bot/bot.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Discord Bot Runner (스켈레톤)
+- 한글 패널/대시보드/알림
+- 대시보드 15초 주기 편집 업데이트
+"""
+from __future__ import annotations
+
+import os
+import asyncio
+import logging
+from typing import Optional
+
+try:
+    import discord  # type: ignore
+    from discord.ext import tasks, commands  # type: ignore
+except Exception:  # pragma: no cover - discord 미설치 시
+    discord = None  # type: ignore
+    tasks = None  # type: ignore
+    commands = None  # type: ignore
+
+try:
+    from ftm2.core.state import StateBus
+except Exception:  # pragma: no cover
+    from core.state import StateBus  # type: ignore
+
+log = logging.getLogger("ftm2.discord")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+if discord is None:  # pragma: no cover - discord.py 미설치 환경
+    def run_discord_bot(bus: StateBus) -> None:
+        """discord.py 미설치 시 단순 경고만 남기고 종료."""
+        log.warning("🔒 Discord 라이브러리가 설치되지 않았습니다. Discord 기능은 비활성화됩니다.")
+        return
+else:
+    # 이 패키지/경로 배치 차이를 흡수 (둘 중 가능한 쪽 사용)
+    try:
+        from ftm2.discord_bot.dashboards import DashboardManager
+        from ftm2.discord_bot.panel import setup_panel_commands
+    except Exception:  # pragma: no cover
+        from discord_bot.dashboards import DashboardManager  # type: ignore
+        from discord_bot.panel import setup_panel_commands  # type: ignore
+
+    class FTMDiscordBot(commands.Bot):
+        def __init__(self, bus: StateBus) -> None:
+            intents = discord.Intents.default()
+            super().__init__(command_prefix="!", intents=intents)
+            self.bus = bus
+            self.dashboard: Optional[DashboardManager] = None
+            self._dash_task_started = False
+
+        async def setup_hook(self) -> None:
+            # 대시보드 매니저 설치
+            self.dashboard = DashboardManager(self)
+            # 패널/명령 등록
+            setup_panel_commands(self)
+
+            # 글로벌 커맨드 동기화
+            try:
+                await self.tree.sync()
+                log.info("[DISCORD] 슬래시 명령 동기화 완료")
+            except Exception as e:  # pragma: no cover
+                log.warning("[DISCORD] 슬래시 동기화 실패: %s", e)
+
+        async def on_ready(self) -> None:  # pragma: no cover - 실제 실행 환경 의존
+            log.info("[DISCORD][READY] 로그인: %s (%s)", self.user, self.user and self.user.id)
+            # 대시보드 초기 메시지 확보
+            try:
+                await self.dashboard.ensure_dashboard_message()
+            except Exception as e:
+                log.warning("[대시보드] 초기화 실패: %s", e)
+
+            # 대시보드 업데이트 루프 시작
+            if not self._dash_task_started:
+                self._dash_task_started = True
+                self._update_dashboard.start()
+
+        @tasks.loop(seconds=15)
+        async def _update_dashboard(self):  # pragma: no cover - 실제 실행 환경 의존
+            try:
+                snap = self.bus.snapshot()
+                await self.dashboard.update(snap)
+            except Exception as e:
+                log.warning("[대시보드] 업데이트 실패: %s", e)
+
+        @_update_dashboard.before_loop  # pragma: no cover - 실제 실행 환경 의존
+        async def _before_update(self):
+            await self.wait_until_ready()
+
+    def run_discord_bot(bus: StateBus) -> None:
+        token = os.getenv("DISCORD_BOT_TOKEN") or ""
+        if not token:
+            log.warning("🔒 DISCORD_BOT_TOKEN 이 비어 있습니다. Discord 기능은 비활성화됩니다.")
+            return
+        bot = FTMDiscordBot(bus)
+
+        async def _main():
+            async with bot:
+                await bot.start(token)
+
+        try:
+            asyncio.run(_main())
+        except KeyboardInterrupt:  # pragma: no cover
+            log.info("[DISCORD] 종료 요청")

--- a/ftm2/discord_bot/dashboards.py
+++ b/ftm2/discord_bot/dashboards.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+대시보드: 주기적으로 편집(update)되는 단일 메시지
+- 채널: CHAN_DASHBOARD_ID
+- 메시지 ID를 runtime/dashboard_msg.json 에 보관 (재시작 시 재사용)
+"""
+from __future__ import annotations
+
+import os
+import json
+import time
+import logging
+from typing import Dict, Any, Optional
+
+import discord  # type: ignore
+
+log = logging.getLogger("ftm2.dashboard")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+DASHBOARD_STORE = os.path.join("runtime", "dashboard_msg.json")
+
+
+def _load_msg_id() -> Optional[int]:
+    try:
+        with open(DASHBOARD_STORE, "r", encoding="utf-8") as f:
+            return int(json.load(f).get("message_id"))
+    except Exception:
+        return None
+
+
+def _save_msg_id(mid: int) -> None:
+    os.makedirs(os.path.dirname(DASHBOARD_STORE), exist_ok=True)
+    with open(DASHBOARD_STORE, "w", encoding="utf-8") as f:
+        json.dump({"message_id": mid}, f)
+
+
+def _fmt_number(x: float) -> str:
+    try:
+        return f"{x:,.4f}"
+    except Exception:
+        return str(x)
+
+
+def _render_dashboard(snap: Dict[str, Any]) -> str:
+    marks = snap.get("marks", {})
+    positions = snap.get("positions", {})
+    uptime = int((snap.get("now_ts", 0) - snap.get("boot_ts", 0)) / 1000)
+    lines = [
+        "📊 **실시간 대시보드**",
+        f"• 가동 시간: `{uptime}s`",
+    ]
+    if marks:
+        sym_parts = []
+        for s, v in marks.items():
+            sym_parts.append(f"{s}: **{_fmt_number(v.get('price', 0.0))}**")
+        lines.append("• 시세(마크프라이스): " + " | ".join(sym_parts))
+    if positions:
+        pos_parts = []
+        for s, p in positions.items():
+            pos_parts.append(
+                f"{s}: 수량 `{_fmt_number(p.get('pa', 0.0))}` / 진입가 `{_fmt_number(p.get('ep',0.0))}` / 평가손익 `{_fmt_number(p.get('up',0.0))}`"
+            )
+        lines.append("• 포지션: " + " | ".join(pos_parts))
+    lines.append("\n_※ 본 메시지는 스팸 방지를 위해 **편집(update)** 방식으로 갱신됩니다._")
+    return "\n".join(lines)
+
+
+class DashboardManager:
+    def __init__(self, bot: discord.Client) -> None:
+        self.bot = bot
+        self.channel_id = int(os.getenv("CHAN_DASHBOARD_ID") or "0")
+        self._msg: Optional[discord.Message] = None
+
+    async def ensure_dashboard_message(self) -> None:
+        if not self.channel_id:
+            log.warning("[대시보드] CHAN_DASHBOARD_ID 가 비어 있습니다.")
+            return
+        ch = self.bot.get_channel(self.channel_id)
+        if ch is None:
+            ch = await self.bot.fetch_channel(self.channel_id)
+
+        # 기존 메시지 재사용 시도
+        mid = _load_msg_id()
+        if mid:
+            try:
+                msg = await ch.fetch_message(mid)  # type: ignore
+                self._msg = msg
+                log.info("[대시보드] 기존 메시지 재사용(mid=%s)", mid)
+                return
+            except Exception:
+                pass
+
+        # 신규 생성
+        msg = await ch.send("대시보드를 초기화하는 중입니다…")
+        self._msg = msg
+        _save_msg_id(msg.id)
+        await msg.edit(content="📊 **실시간 대시보드**\n초기화 완료. 곧 데이터가 표시됩니다.")
+
+    async def update(self, snapshot: Dict[str, Any]) -> None:
+        if not self._msg:
+            return
+        content = _render_dashboard(snapshot)
+        await self._msg.edit(content=content)
+        log.info("[대시보드] 업데이트 완료")

--- a/ftm2/discord_bot/panel.py
+++ b/ftm2/discord_bot/panel.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+슬래시 명령(한글 현지화) & 패널 메시지
+- Discord 제한상 command 이름은 영문으로 두되, name_localizations={"ko": "…"} 로 **한글 노출**
+"""
+from __future__ import annotations
+
+import os
+import logging
+import discord  # type: ignore
+from discord import app_commands  # type: ignore
+from discord.ext import commands  # type: ignore
+
+try:
+    from ftm2.discord_bot.views import ControlPanelView
+except Exception:  # pragma: no cover
+    from discord_bot.views import ControlPanelView  # type: ignore
+
+log = logging.getLogger("ftm2.panel")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+def _panel_channel(bot: commands.Bot) -> discord.TextChannel | None:
+    panel_id = int(os.getenv("CHAN_PANEL_ID") or "0")
+    ch = bot.get_channel(panel_id) if panel_id else None
+    return ch if isinstance(ch, discord.TextChannel) else None
+
+
+def setup_panel_commands(bot: commands.Bot) -> None:
+    tree = bot.tree
+
+    # /mode → '모드' 로 한글 노출
+    @tree.command(
+        name="mode",
+        description="실행 모드를 전환합니다.",
+        name_localizations={"ko": "모드"},
+        description_localizations={"ko": "실행 모드를 전환합니다. (paper/testnet/live)"},
+    )
+    @app_commands.describe(kind="모드를 선택하세요: paper/testnet/live")
+    @app_commands.rename(kind="모드")
+    async def mode(inter: discord.Interaction, kind: str):
+        # 실제 변경은 Orchestrator와의 계약 필요(M3/M4)
+        await inter.response.send_message(f"⚙️ 모드 전환 요청: `{kind}` (스켈레톤 — 추후 반영)", ephemeral=True)
+
+    # /auto → '자동'
+    @tree.command(
+        name="auto",
+        description="자동 매매를 켜거나 끕니다.",
+        name_localizations={"ko": "자동"},
+        description_localizations={"ko": "자동 매매를 켜거나 끕니다."},
+    )
+    @app_commands.describe(state="상태 선택: on/off")
+    @app_commands.rename(state="상태")
+    async def auto(inter: discord.Interaction, state: str):
+        await inter.response.send_message(f"🔄 자동 매매: `{state}` (스켈레톤)", ephemeral=True)
+
+    # /close → '청산'
+    @tree.command(
+        name="close",
+        description="포지션을 청산합니다.",
+        name_localizations={"ko": "청산"},
+        description_localizations={"ko": "포지션을 청산합니다. (all/BTC/ETH)"},
+    )
+    @app_commands.describe(scope="대상: all/BTC/ETH")
+    @app_commands.rename(scope="대상")
+    async def close(inter: discord.Interaction, scope: str):
+        await inter.response.send_message(f"🧹 청산 요청: `{scope}` (스켈레톤)", ephemeral=True)
+
+    # /reverse → '반전'
+    @tree.command(
+        name="reverse",
+        description="해당 심볼 포지션을 반전합니다.",
+        name_localizations={"ko": "반전"},
+        description_localizations={"ko": "해당 심볼 포지션을 반전합니다."},
+    )
+    async def reverse(inter: discord.Interaction, symbol: str):
+        await inter.response.send_message(f"🔁 반전 요청: `{symbol}` (스켈레톤)", ephemeral=True)
+
+    # /flat → '평탄'
+    @tree.command(
+        name="flat",
+        description="해당 심볼 포지션을 0으로 만듭니다.",
+        name_localizations={"ko": "평탄"},
+        description_localizations={"ko": "해당 심볼 포지션을 0으로 만듭니다."},
+    )
+    async def flat(inter: discord.Interaction, symbol: str):
+        await inter.response.send_message(f"🧊 평탄 요청: `{symbol}` (스켈레톤)", ephemeral=True)
+
+    # 컨트롤 패널 메시지(버튼 포함) — 한글
+    @tree.command(
+        name="panel",
+        description="컨트롤 패널 메시지를 채널에 게시합니다.",
+        name_localizations={"ko": "패널"},
+        description_localizations={"ko": "컨트롤 패널 메시지를 채널에 게시합니다."},
+    )
+    async def panel_cmd(inter: discord.Interaction):
+        ch = _panel_channel(bot)
+        if ch is None:
+            await inter.response.send_message("⚠️ 패널 채널(CHAN_PANEL_ID)이 설정되지 않았습니다.", ephemeral=True)
+            return
+        await ch.send("🛠️ **컨트롤 패널** — 아래 버튼으로 자동 매매를 제어하세요.", view=ControlPanelView())
+        await inter.response.send_message("✅ 패널을 게시했습니다.", ephemeral=True)
+
+    # 간단 알림 테스트 — 한글
+    @tree.command(
+        name="alert",
+        description="알림 채널로 테스트 메시지를 보냅니다.",
+        name_localizations={"ko": "알림"},
+        description_localizations={"ko": "알림 채널로 테스트 메시지를 보냅니다."},
+    )
+    async def alert_cmd(inter: discord.Interaction, 내용: str):
+        alert_id = int(os.getenv("CHAN_ALERTS_ID") or "0")
+        ch = bot.get_channel(alert_id) if alert_id else None
+        if isinstance(ch, discord.TextChannel):
+            await ch.send(f"🔔 **알림**: {내용}")
+            await inter.response.send_message("✅ 전송 완료", ephemeral=True)
+        else:
+            await inter.response.send_message("⚠️ 알림 채널(CHAN_ALERTS_ID)이 설정되지 않았습니다.", ephemeral=True)

--- a/ftm2/discord_bot/views.py
+++ b/ftm2/discord_bot/views.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+컨트롤 패널용 기본 버튼 View (스켈레톤)
+- 실제 자동매매 토글/모드 변경은 M3/M4에서 Orchestrator와 연결 예정
+"""
+from __future__ import annotations
+import logging
+import discord  # type: ignore
+
+log = logging.getLogger("ftm2.views")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+class ControlPanelView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @discord.ui.button(label="자동 매매 ON", style=discord.ButtonStyle.success, custom_id="auto_on")
+    async def auto_on(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message("✅ 자동 매매: **ON** (스켈레톤 — 실제 반영은 추후 티켓에서 연결됩니다)", ephemeral=True)
+
+    @discord.ui.button(label="자동 매매 OFF", style=discord.ButtonStyle.danger, custom_id="auto_off")
+    async def auto_off(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message("⛔ 자동 매매: **OFF** (스켈레톤 — 실제 반영은 추후 티켓에서 연결됩니다)", ephemeral=True)

--- a/ftm2/tests/__init__.py
+++ b/ftm2/tests/__init__.py
@@ -1,0 +1,1 @@
+# test package

--- a/ftm2/tests/test_env_state.py
+++ b/ftm2/tests/test_env_state.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from ftm2.core.env import load_env_chain
+from ftm2.core.state import StateBus
+
+
+def test_load_env_chain(tmp_path, monkeypatch):
+    token_file = tmp_path / "token.env"
+    token_file.write_text("KEY1=token\nKEY2=token\n")
+    env_file = tmp_path / ".env"
+    env_file.write_text("KEY2=env\nKEY3=env\n")
+
+    monkeypatch.setenv("KEY1", "os")
+
+    env = load_env_chain(paths=(str(token_file), str(env_file)))
+    assert env["KEY1"] == "os"
+    assert env["KEY2"] == "token"
+    assert env["KEY3"] == "env"
+
+
+def test_state_bus_snapshot():
+    bus = StateBus()
+    bus.update_mark("BTCUSDT", 100.0, 123)
+    bus.update_kline("BTCUSDT", "1m", {"o":1})
+    bus.set_positions([{"symbol": "BTCUSDT"}])
+    bus.set_account({"balance": 1})
+    snap = bus.snapshot()
+    assert snap["marks"]["BTCUSDT"]["price"] == 100.0
+    assert snap["klines"][("BTCUSDT", "1m")]["o"] == 1
+    assert snap["positions"][0]["symbol"] == "BTCUSDT"
+    assert snap["account"]["balance"] == 1
+    assert isinstance(snap["ts"], int)

--- a/patch.txt
+++ b/patch.txt
@@ -8,3 +8,8 @@
 # - feat(state): 전역 스냅샷 버스 규격 확정
 # - feat(discord): /mode /auto /close 명령 스펙 고정
 # - feat(risk): ATR-unit 파라미터 세트 확정(R%, day-cut, corr-cap)
+2025-09-03 v0.1.0
+- feat(connector): add Binance USDⓈ-M client stubs with testnet/live toggle (REST/WS)
+- feat(orch): add minimal orchestrator & state bus with env loader, heartbeat, and REST mark-price poller
+- feat(streams): add StreamManager for kline/markPrice/user streams and StateBus updates
+- feat(discord): add Korean-localized slash commands, dashboard auto-update, and control panel skeleton


### PR DESCRIPTION
## Summary
- integrate Discord bot runner with dashboard updates and command panel using Korean-localized slash commands
- start Discord bot in orchestrator for optional runtime updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7c09eac0c832dad14172208213d3c