### PR TITLE
feat(exec): add order router with execution config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,17 @@ CORR_CAP_PER_SIDE=0.65
 RISK_ATR_K=2.0
 RISK_MIN_NOTIONAL=20
 # RISK_EQUITY_OVERRIDE=1000    # 키 없을 때 테스트용(선택)
+
+# [ENV:EXECUTION]
+EXEC_ACTIVE=0            # 0=dry-run, 1=live (주의: BinanceClient order_active=False면 실주문 시도해도 거부)
+EXEC_COOLDOWN_S=5        # 심볼별 최소 간격(sec)
+EXEC_TOL_REL=0.05        # |delta| < |target|*tol_rel 이면 skip
+EXEC_TOL_ABS=0.0         # |delta| < tol_abs 이면 skip
+EXEC_ORDER_TYPE=MARKET
+EXEC_REDUCE_ONLY=true
+
+# [ENV:PROTECTION]
+PROT_SLIP_WARN_PCT=0.003   # 슬리피지 경고 임계(=0.3%)
+PROT_SLIP_MAX_PCT=0.008    # 슬리피지 최대 임계(=0.8%)
+PROT_STALE_REL=0.5         # |delta| > |target|*0.5 이면 정체로 간주
+PROT_STALE_SECS=20         # 마지막 주문 이후 N초 동안 정체면 넛지

--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -72,6 +72,20 @@ except Exception:  # pragma: no cover
     from trade.risk import RiskEngine, RiskConfig  # type: ignore
     from core.config import load_forecast_cfg, load_risk_cfg  # type: ignore
 
+try:
+    from ftm2.trade.router import OrderRouter, ExecConfig
+    from ftm2.core.config import load_exec_cfg
+except Exception:  # pragma: no cover
+    from trade.router import OrderRouter, ExecConfig  # type: ignore
+    from core.config import load_exec_cfg  # type: ignore
+
+try:
+    from ftm2.trade.reconcile import Reconciler, ProtectConfig
+    from ftm2.core.config import load_protect_cfg
+except Exception:  # pragma: no cover
+    from trade.reconcile import Reconciler, ProtectConfig  # type: ignore
+    from core.config import load_protect_cfg  # type: ignore
+
 
 
 log = logging.getLogger("ftm2.orch")
@@ -118,6 +132,30 @@ class Orchestrator:
                 atr_k=rcfg_view.atr_k,
                 min_notional=rcfg_view.min_notional,
                 equity_override=rcfg_view.equity_override,
+            ),
+        )
+
+        exv = load_exec_cfg(self.db)
+        self.exec_router = OrderRouter(
+            self.cli,
+            ExecConfig(
+                active=exv.active,
+                cooldown_s=exv.cooldown_s,
+                tol_rel=exv.tol_rel,
+                tol_abs=exv.tol_abs,
+                order_type=exv.order_type,
+                reduce_only=exv.reduce_only,
+            ),
+        )
+
+        pcv = load_protect_cfg(self.db)
+        self.reconciler = Reconciler(
+            self.bus, self.db, self.exec_router,
+            ProtectConfig(
+                slip_warn_pct=pcv.slip_warn_pct,
+                slip_max_pct=pcv.slip_max_pct,
+                stale_rel=pcv.stale_rel,
+                stale_secs=pcv.stale_secs,
             ),
         )
 
@@ -221,6 +259,48 @@ class Orchestrator:
                     log.info("[RISK_CFG_RELOAD] 적용: %s", self.risk.cfg)
             except Exception as e:
                 log.warning("[RISK_CFG_RELOAD] 실패: %s", e)
+
+            try:
+                new_exec = load_exec_cfg(self.db)
+                cur = self.exec_router.cfg
+                if (
+                    cur.active != new_exec.active
+                    or cur.cooldown_s != new_exec.cooldown_s
+                    or cur.tol_rel != new_exec.tol_rel
+                    or cur.tol_abs != new_exec.tol_abs
+                    or cur.order_type != new_exec.order_type
+                    or cur.reduce_only != new_exec.reduce_only
+                ):
+                    self.exec_router.cfg = ExecConfig(
+                        active=new_exec.active,
+                        cooldown_s=new_exec.cooldown_s,
+                        tol_rel=new_exec.tol_rel,
+                        tol_abs=new_exec.tol_abs,
+                        order_type=new_exec.order_type,
+                        reduce_only=new_exec.reduce_only,
+                    )
+                    log.info("[EXEC_CFG_RELOAD] 적용: %s", self.exec_router.cfg)
+            except Exception as e:
+                log.warning("[EXEC_CFG_RELOAD] 실패: %s", e)
+
+            try:
+                new_pcv = load_protect_cfg(self.db)
+                rc = self.reconciler.cfg
+                if (
+                    rc.slip_warn_pct != new_pcv.slip_warn_pct
+                    or rc.slip_max_pct != new_pcv.slip_max_pct
+                    or rc.stale_rel != new_pcv.stale_rel
+                    or rc.stale_secs != new_pcv.stale_secs
+                ):
+                    self.reconciler.cfg = ProtectConfig(
+                        slip_warn_pct=new_pcv.slip_warn_pct,
+                        slip_max_pct=new_pcv.slip_max_pct,
+                        stale_rel=new_pcv.stale_rel,
+                        stale_secs=new_pcv.stale_secs,
+                    )
+                    log.info("[PROTECT_CFG_RELOAD] 적용: %s", self.reconciler.cfg)
+            except Exception as e:
+                log.warning("[PROTECT_CFG_RELOAD] 실패: %s", e)
             time.sleep(period_s)
 
 
@@ -319,6 +399,46 @@ class Orchestrator:
             time.sleep(period_s)
 
 
+    def _exec_loop(self, period_s: float = 1.0) -> None:
+        """
+        RiskEngine이 계산한 targets를 소비하여 주문(또는 드라이런)을 수행.
+        """
+        while not self._stop.is_set():
+            snap = self.bus.snapshot()
+            try:
+                res = self.exec_router.sync(snap)
+                for r in res:
+                    msg = (
+                        f"{r['mode']} {r['symbol']} {r['side']} Δ={r['delta_qty']:.6f} "
+                        f"qty={r['qty_sent']:.6f} {r['reason']}"
+                    )
+                    log.info("[EXEC] %s", msg)
+                    try:
+                        self.db.record_event("INFO", "exec", msg)
+                    except Exception:
+                        pass
+            except Exception as e:
+                log.warning("[EXEC_ERR] %s", e)
+            time.sleep(period_s)
+
+
+    def _reconcile_loop(self, period_s: float = 0.5) -> None:
+        while not self._stop.is_set():
+            snap = self.bus.snapshot()
+            try:
+                res = self.reconciler.process(snap)
+                if res.get("fills_saved"):
+                    log.info(
+                        "[RECON] fills_saved=%s slip_warns=%d nudges=%d",
+                        res["fills_saved"],
+                        len(res.get("slip_warns", [])),
+                        len(res.get("nudges", [])),
+                    )
+            except Exception as e:
+                log.warning("[RECON] loop err: %s", e)
+            time.sleep(period_s)
+
+
     def start(self) -> None:
         # 심볼별 마크프라이스 폴러는 M1.1 임시 → WS로 대체
         # for sym in self.symbols:
@@ -346,6 +466,16 @@ class Orchestrator:
 
         # 리스크 루프 시작
         t = threading.Thread(target=self._risk_loop, name="risk", daemon=True)
+        t.start()
+        self._threads.append(t)
+
+        # 실행 루프 시작
+        t = threading.Thread(target=self._exec_loop, name="exec", daemon=True)
+        t.start()
+        self._threads.append(t)
+
+        # 리컨실 루프 시작
+        t = threading.Thread(target=self._reconcile_loop, name="reconcile", daemon=True)
         t.start()
         self._threads.append(t)
 

--- a/ftm2/data/streams.py
+++ b/ftm2/data/streams.py
@@ -178,6 +178,21 @@ class StreamManager:
                     self.bus.set_positions(pos_map)
             elif evt == "ORDER_TRADE_UPDATE":
                 o = msg.get("o") or {}
+                rec = {
+                    "symbol": (o.get("s") or "").upper(),
+                    "side": o.get("S"),
+                    "execType": o.get("x"),
+                    "status": o.get("X"),
+                    "lastQty": float(o.get("l", 0.0)),
+                    "lastPrice": float(o.get("L", 0.0)),
+                    "cumQty": float(o.get("Z", 0.0)),
+                    "avgPrice": float(o.get("ap", 0.0)),
+                    "orderId": o.get("i"),
+                    "clientOrderId": o.get("c"),
+                    "commission": float(o.get("n", 0.0)),
+                    "ts": int(msg.get("E") or o.get("T") or 0),
+                }
+                self.bus.push_fill(rec)
                 log.info("[USER_STREAM][OTU] %s %s %s %s", o.get("s"), o.get("S"), o.get("X"), o.get("ap"))
         except Exception as e:
             log.exception("user cb err: %s", e)

--- a/ftm2/tests/test_env_state.py
+++ b/ftm2/tests/test_env_state.py
@@ -27,7 +27,7 @@ def test_state_bus_snapshot():
     bus = StateBus()
     bus.update_mark("BTCUSDT", 100.0, 123)
     bus.update_kline("BTCUSDT", "1m", {"o":1})
-    bus.set_positions([{"symbol": "BTCUSDT"}])
+    bus.set_positions({"BTCUSDT": {"symbol": "BTCUSDT"}})
     bus.set_account({"balance": 1})
     bus.update_forecast("BTCUSDT", "1m", {"score": 0.1})
     bus.set_targets({"BTCUSDT": {"target_qty": 1.0}})
@@ -35,7 +35,7 @@ def test_state_bus_snapshot():
     snap = bus.snapshot()
     assert snap["marks"]["BTCUSDT"]["price"] == 100.0
     assert snap["klines"][("BTCUSDT", "1m")]["o"] == 1
-    assert snap["positions"][0]["symbol"] == "BTCUSDT"
+    assert snap["positions"]["BTCUSDT"]["symbol"] == "BTCUSDT"
     assert snap["account"]["balance"] == 1
     assert snap["features"] == {}
     assert snap["regimes"] == {}
@@ -44,3 +44,13 @@ def test_state_bus_snapshot():
     assert snap["risk"]["equity"] == 1000
     assert isinstance(snap["boot_ts"], int)
     assert isinstance(snap["now_ts"], int)
+
+
+def test_state_bus_fills_queue():
+    bus = StateBus()
+    bus.push_fill({"symbol": "BTCUSDT", "side": "BUY"})
+    bus.push_fill({"symbol": "ETHUSDT", "side": "SELL"})
+    out = bus.drain_fills()
+    assert len(out) == 2
+    assert out[0]["symbol"] == "BTCUSDT"
+    assert bus.drain_fills() == []

--- a/ftm2/trade/reconcile.py
+++ b/ftm2/trade/reconcile.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""
+Reconciler: 체결 기록/슬리피지 감시/라이트 리트라이(nudge)
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Tuple, List, Any, Optional
+import time
+import logging
+
+try:
+    from ftm2.core.persistence import Persistence
+    from ftm2.core.state import StateBus
+    from ftm2.trade.router import OrderRouter
+    from ftm2.discord_bot.notify import enqueue_alert
+except Exception:  # pragma: no cover
+    from core.persistence import Persistence            # type: ignore
+    from core.state import StateBus                     # type: ignore
+    from trade.router import OrderRouter                # type: ignore
+    from discord_bot.notify import enqueue_alert        # type: ignore
+
+log = logging.getLogger("ftm2.recon")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+@dataclass
+class ProtectConfig:
+    slip_warn_pct: float = 0.003   # 0.3%
+    slip_max_pct: float = 0.008   # 0.8%
+    stale_rel: float = 0.5        # |delta| > |target|*0.5
+    stale_secs: float = 20.0      # 마지막 송신 후 20초 지나도 미이행이면 넛지
+
+
+# [ANCHOR:RECONCILE]
+class Reconciler:
+    def __init__(self, bus: StateBus, db: Persistence, router: OrderRouter, cfg: ProtectConfig = ProtectConfig()) -> None:
+        self.bus = bus
+        self.db = db
+        self.router = router
+        self.cfg = cfg
+
+    def _save_fill(self, rec: Dict[str, Any]) -> None:
+        # qty 부호(매수 +, 매도 -)
+        side = (rec.get("side") or "").upper()
+        lqty = float(rec.get("lastQty") or rec.get("cumQty") or 0.0)
+        qty_signed = lqty if side == "BUY" else -lqty if side == "SELL" else lqty
+        px = float(rec.get("lastPrice") or rec.get("avgPrice") or 0.0)
+
+        self.db.save_trade({
+            "ts": int(rec.get("ts") or time.time()*1000),
+            "symbol": rec.get("symbol"),
+            "side": side,
+            "qty": qty_signed,
+            "px": px,
+            "type": "FILL",
+            "fee": float(rec.get("commission") or 0.0),
+            "order_id": str(rec.get("orderId") or ""),
+            "client_order_id": rec.get("clientOrderId"),
+            "link_id": None,
+        })
+
+    def _slip_check(self, rec: Dict[str, Any], snapshot: Dict[str, Any]) -> Optional[str]:
+        sym = rec.get("symbol")
+        mark = float((snapshot.get("marks") or {}).get(sym, {}).get("price") or 0.0)
+        fill_px = float(rec.get("lastPrice") or rec.get("avgPrice") or 0.0)
+        if mark <= 0.0 or fill_px <= 0.0:
+            return None
+        slip = abs(fill_px - mark) / mark
+        if slip >= self.cfg.slip_warn_pct:
+            level = "최대" if slip >= self.cfg.slip_max_pct else "경고"
+            txt = f"⚠️ 슬리피지 {level}: {sym} fill={fill_px:.2f} / mark={mark:.2f} ({slip*100:.2f}%)"
+            log.warning("[RECON][SLIP] %s", txt)
+            try:
+                enqueue_alert(txt, intent="logs")
+            except Exception:
+                pass
+            return txt
+        return None
+
+    def _maybe_nudge(self, snapshot: Dict[str, Any]) -> List[str]:
+        """
+        타깃-포지션 차이가 큰데 오랫동안 미이행이면 라우터 쿨다운을 해제(즉시 재시도 허용).
+        """
+        out: List[str] = []
+        targets = snapshot.get("targets") or {}
+        positions = snapshot.get("positions") or {}
+        now_ms = int(snapshot.get("now_ts") or time.time()*1000)
+
+        for sym, tgt in targets.items():
+            target_qty = float(tgt.get("target_qty") or 0.0)
+            pos = float((positions.get(sym) or {}).get("pa") or 0.0)
+            delta = target_qty - pos
+            # 상대 기준
+            if abs(delta) <= max(0.0, abs(target_qty) * self.cfg.stale_rel):
+                continue
+            last = self.router.last_sent_ms(sym) or 0
+            if (now_ms - last) / 1000.0 < self.cfg.stale_secs:
+                continue
+            # 넛지!
+            self.router.nudge(sym)
+            msg = f"🔁 넛지: {sym} Δ={delta:.6f} (target={target_qty:.6f}, pos={pos:.6f}) — 라우터 쿨다운 해제"
+            log.info("[RECON][NUDGE] %s", msg)
+            try:
+                enqueue_alert(msg, intent="logs")
+            except Exception:
+                pass
+            out.append(sym)
+        return out
+
+    def process(self, snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        fills = self.bus.drain_fills(200)
+        slip_msgs: List[str] = []
+        for f in fills:
+            try:
+                self._save_fill(f)
+                log.info("[RECON][FILL] %s %s l=%s L=%s Z=%s ap=%s",
+                         f.get("symbol"), f.get("side"), f.get("lastQty"), f.get("lastPrice"), f.get("cumQty"), f.get("avgPrice"))
+            except Exception as e:
+                log.warning("[RECON] save_fill 실패: %s", e)
+            m = self._slip_check(f, snapshot)
+            if m: slip_msgs.append(m)
+
+        nudged = self._maybe_nudge(snapshot)
+        return {"fills_saved": len(fills), "slip_warns": slip_msgs, "nudges": nudged}

--- a/ftm2/trade/router.py
+++ b/ftm2/trade/router.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""
+Order Router: targets -> orders (dry-run by default)
+- LOT_SIZE step, MIN_NOTIONAL 준수
+- cooldown / tolerance
+- reduceOnly 처리
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Tuple, List, Any, Optional
+import time
+import math
+import logging
+
+try:
+    from ftm2.exchange.binance import BinanceClient
+except Exception:
+    from exchange.binance import BinanceClient  # type: ignore
+
+log = logging.getLogger("ftm2.exec")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+@dataclass
+class ExecConfig:
+    active: bool = False          # 실주문 on/off
+    cooldown_s: float = 5.0       # 심볼별 최소 간격
+    tol_rel: float = 0.05         # |delta| < |target|*tol_rel 이면 skip
+    tol_abs: float = 0.0          # |delta| < tol_abs 이면 skip
+    order_type: str = "MARKET"
+    reduce_only: bool = True      # 청산·감소는 reduceOnly
+
+def _round_step(x: float, step: float) -> float:
+    if step <= 0: return x
+    # binance step은 소수 1e-? 형태가 많음 → 반올림 오차 방지
+    k = round(x / step)
+    return k * step
+
+# [ANCHOR:ORDER_ROUTER]
+class OrderRouter:
+    def __init__(self, client: BinanceClient, cfg: ExecConfig) -> None:
+        self.cli = client
+        self.cfg = cfg
+        self._last_sent_ms: Dict[str, int] = {}  # sym -> epoch_ms
+        self._meta: Dict[str, Dict[str, float]] = {}  # sym -> {step,min_notional}
+        self._warm = False
+
+    # ---- exchange meta ----
+    def _ensure_meta(self, symbols: List[str]) -> None:
+        if self._warm:
+            return
+        r = self.cli.exchange_info(symbols)
+        if not r.get("ok"):
+            log.warning("[EXEC] exchangeInfo 실패: %s", r.get("error"))
+            # 기본값 보수적으로
+            for s in symbols:
+                self._meta.setdefault(s, {"step": 0.001, "min_notional": 5.0})
+            self._warm = True
+            return
+        info = r["data"]
+        arr = info.get("symbols") or []
+        for si in arr:
+            sym = si.get("symbol")
+            step = 0.001
+            min_notional = 5.0
+            for f in si.get("filters", []):
+                ft = f.get("filterType")
+                if ft == "LOT_SIZE":
+                    try:
+                        step = float(f.get("stepSize", step))
+                    except Exception:
+                        pass
+                # 선물은 'MIN_NOTIONAL' 또는 'NOTIONAL' 형식이 존재
+                if ft in ("MIN_NOTIONAL", "NOTIONAL"):
+                    try:
+                        mn = f.get("minNotional") or f.get("notional")
+                        if mn is not None:
+                            min_notional = float(mn)
+                    except Exception:
+                        pass
+                # 일부 선물은 MARKET_LOT_SIZE만 노출되기도 함 → 보조
+                if ft == "MARKET_LOT_SIZE" and step == 0.001:
+                    try:
+                        step = float(f.get("stepSize", step))
+                    except Exception:
+                        pass
+            self._meta[sym] = {"step": step, "min_notional": min_notional}
+        self._warm = True
+
+    # ---- plan & send ----
+    def _too_soon(self, sym: str) -> bool:
+        last = self._last_sent_ms.get(sym, 0)
+        return (time.time() * 1000 - last) < (self.cfg.cooldown_s * 1000)
+
+    def _skip_tolerance(self, delta: float, target: float) -> bool:
+        if abs(delta) < self.cfg.tol_abs:
+            return True
+        if abs(target) > 0 and abs(delta) < abs(target) * self.cfg.tol_rel:
+            return True
+        return False
+
+    def sync(self, snapshot: Dict[str, Any]) -> List[Dict[str, Any]]:
+        symbols = list((snapshot.get("targets") or {}).keys())
+        if not symbols:
+            return []
+        self._ensure_meta(symbols)
+
+        positions = snapshot.get("positions") or {}
+        marks = snapshot.get("marks") or {}
+        targets = snapshot.get("targets") or {}
+
+        results: List[Dict[str, Any]] = []
+        for sym, tgt in targets.items():
+            price = float((marks.get(sym) or {}).get("price") or 0.0)
+            pos = float((positions.get(sym) or {}).get("pa") or 0.0)  # positionAmt
+            target_qty = float(tgt.get("target_qty") or 0.0)
+            delta = target_qty - pos
+
+            if self._too_soon(sym):
+                results.append({
+                    "symbol": sym, "side": "SKIP", "delta_qty": delta, "qty_sent": 0.0,
+                    "price": price, "reason": "COOLDOWN", "mode": "DRY" if not self.cfg.active else "LIVE",
+                    "result": None
+                })
+                continue
+
+            if self._skip_tolerance(delta, target_qty):
+                results.append({
+                    "symbol": sym, "side": "SKIP", "delta_qty": delta, "qty_sent": 0.0,
+                    "price": price, "reason": "TOL", "mode": "DRY" if not self.cfg.active else "LIVE",
+                    "result": None
+                })
+                continue
+
+            side = "BUY" if delta > 0 else "SELL"
+            step = (self._meta.get(sym) or {}).get("step", 0.001)
+            min_notional = (self._meta.get(sym) or {}).get("min_notional", 5.0)
+            qty_raw = abs(delta)
+            qty = _round_step(qty_raw, step)
+            notional = qty * price
+
+            if qty <= 0.0:
+                results.append({
+                    "symbol": sym, "side": "SKIP", "delta_qty": delta, "qty_sent": 0.0,
+                    "price": price, "reason": "STEP_ZERO", "mode": "DRY" if not self.cfg.active else "LIVE",
+                    "result": None
+                })
+                continue
+            if price <= 0.0 or notional < min_notional:
+                results.append({
+                    "symbol": sym, "side": "SKIP", "delta_qty": delta, "qty_sent": 0.0,
+                    "price": price, "reason": "MIN_NOTIONAL", "mode": "DRY" if not self.cfg.active else "LIVE",
+                    "result": None
+                })
+                continue
+
+            reduce_only = False
+            # 현재 포지션 절대값이 줄어드는 방향이면 reduceOnly
+            if (pos > 0 and side == "SELL") or (pos < 0 and side == "BUY") or target_qty == 0.0:
+                reduce_only = self.cfg.reduce_only
+
+            payload = {
+                "symbol": sym,
+                "side": side,
+                "type": self.cfg.order_type,
+                "quantity": f"{qty:.10f}".rstrip("0").rstrip("."),  # 문자열 권장
+            }
+            if reduce_only:
+                payload["reduceOnly"] = True
+
+            mode = "LIVE" if self.cfg.active else "DRY"
+            if not self.cfg.active:
+                log.info("[EXEC_DRY] %s %s qty=%s reason=PLAN", sym, side, payload["quantity"])
+                self._last_sent_ms[sym] = int(time.time() * 1000)
+                results.append({
+                    "symbol": sym, "side": side, "delta_qty": delta, "qty_sent": qty,
+                    "price": price, "reason": "DRY", "mode": mode, "result": {"ok": True, "dry": True}
+                })
+                continue
+
+            # 실주문: BinanceClient 가 order_active=False 면 스텁에러가 온다 → 그대로 노출
+            r = self.cli.create_order(payload)
+            if r.get("ok"):
+                log.info("[EXEC] %s %s qty=%s @~%g", sym, side, payload["quantity"], price)
+                self._last_sent_ms[sym] = int(time.time() * 1000)
+            else:
+                log.warning("[EXEC_ERR] %s %s %s", sym, side, r.get("error"))
+            results.append({
+                "symbol": sym, "side": side, "delta_qty": delta, "qty_sent": qty,
+                "price": price, "reason": "SENT" if r.get("ok") else "ERR",
+                "mode": mode, "result": r
+            })
+        return results
+
+    def last_sent_ms(self, sym: str) -> Optional[int]:
+        """해당 심볼의 마지막 주문(또는 드라이런 전송) 시각(ms)"""
+        return self._last_sent_ms.get(sym)
+
+    def nudge(self, sym: str) -> None:
+        """쿨다운을 즉시 해제해 다음 루프에서 바로 재시도 가능하게 함"""
+        self._last_sent_ms[sym] = 0

--- a/patch.txt
+++ b/patch.txt
@@ -30,3 +30,7 @@
 - feat(risk): ATR-unit 사이징, 사이드 상관캡, 데일리컷을 갖춘 리스크 엔진 추가 — ENV/DB 로드 및 버스/알림 연동
 # (요약) feat(milestone): M1 골격 & 테스트넷 라운드트립 완료
 
+2025-09-15 v0.3.0
+- feat(exec): 타깃→주문 라우터 추가(쿨다운/허용오차/LOT_STEP·MIN_NOTIONAL/ReduceOnly/드라이런·실주문 토글) 및 핫리로드 연동
+- feat(reconcile): 유저스트림 체결 수집→DB 기록, 슬리피지 경고/알림, 타깃-포지션 정체 시 라우터 넛지(쿨다운 해제) 추가
+


### PR DESCRIPTION
## Summary
- add configurable OrderRouter that converts targets into executable orders
- load execution settings from DB/ENV and hot-reload
- wire execution loop into orchestrator and document EXEC_* variables
- record fills, monitor slippage, and nudge router when targets stagnate
- hot-reload protection settings and expose PROT_* environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3c74234832d9a1c210fa7d37049