### PR TITLE
feat: add strategy adapter & ops HTTP monitoring

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -97,3 +97,18 @@ BT_OUT_DIR=./reports
 # BT_START_MS=1717200000000
 # BT_END_MS=1719850000000
 
+# [ENV:STRATEGY]
+# 백테스트/리플레이에서 사용할 전략 어댑터
+# - dummy: 내부 모멘텀(EMA) 더미
+# - ensemble: 실전 ForecastEnsemble 사용(가용 시)
+# - custom: STRAT_CLASS로 지정한 클래스 사용
+STRAT_MODE=ensemble
+# STRAT_CLASS=ftm2.my_strategy.MyAdapter   # (STRAT_MODE=custom 일 때)
+# STRAT_PARAMS={"lookback":24,"strong_thr":0.6}
+
+# [ENV:OPS_HTTP]
+OPS_HTTP_ENABLED=true
+OPS_HTTP_HOST=0.0.0.0
+OPS_HTTP_PORT=8080
+OPS_READY_MAX_SKEW_S=15
+

--- a/ftm2/ops/httpd.py
+++ b/ftm2/ops/httpd.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""
+Ops HTTPD: 헬스/레디/메트릭/KPI 노출 (표준 라이브러리만 사용)
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import threading, time, json, logging
+
+try:
+    from ftm2.core.state import StateBus
+except Exception:
+    from core.state import StateBus  # type: ignore
+
+log = logging.getLogger("ftm2.ops.http")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+@dataclass
+class OpsHttpConfig:
+    enabled: bool = True
+    host: str = "0.0.0.0"
+    port: int = 8080
+    ready_max_skew_s: float = 15.0  # 최신 mark ts와 현재의 최대 허용 지연
+
+class _Handler(BaseHTTPRequestHandler):
+    # 주입: 클래스 변수로 공유
+    bus: Optional[StateBus] = None
+    cfg: Optional[OpsHttpConfig] = None
+
+    def _write(self, code: int, body: str, content_type: str = "text/plain; charset=utf-8") -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body.encode("utf-8"))
+
+    def log_message(self, fmt, *args):
+        # 표준 http.server noisy 로그 억제 → 필요시 INFO로
+        log.debug("[OPS_HTTP] " + fmt, *args)
+
+    def do_GET(self):
+        p = self.path.split("?")[0]
+        try:
+            if p == "/healthz":
+                return self._write(200, "ok")
+            if p == "/readyz":
+                return self._readyz()
+            if p == "/metrics":
+                return self._metrics()
+            if p == "/kpi":
+                return self._kpi()
+            return self._write(404, "not found")
+        except Exception as e:
+            log.warning("[OPS_HTTP][ERR] %s %s", p, e)
+            return self._write(500, "error")
+
+    # ---- endpoints ----
+    def _readyz(self):
+        snap = self.bus.snapshot() if self.bus else {}
+        now_ms = int(time.time() * 1000)
+        marks = snap.get("marks") or {}
+        # 최신 가격 이벤트 나이(초)
+        ages = []
+        for m in marks.values():
+            ts = int(m.get("ts") or 0)
+            if ts > 0:
+                ages.append(max(0.0, (now_ms - ts) / 1000.0))
+        max_age = max(ages) if ages else 9e9
+        ok = (max_age <= float(self.cfg.ready_max_skew_s if self.cfg else 15.0))
+        body = "ready" if ok else f"stale(max_age={max_age:.1f}s)"
+        return self._write(200 if ok else 503, body)
+
+    def _metrics(self):
+        snap = self.bus.snapshot() if self.bus else {}
+        now_s = int(time.time())
+        boot_ts = int(snap.get("boot_ts") or now_s * 1000)
+        uptime = max(0, now_s - int(boot_ts / 1000))
+
+        risk = snap.get("risk") or {}
+        equity = float(risk.get("equity") or 0.0)
+        day_pnl_pct = float(risk.get("day_pnl_pct") or 0.0)
+        guard = snap.get("guard") or {}
+        eq = guard.get("exec_quality") or {}
+        ol = guard.get("exec_ledger") or {}
+        open_orders = sum(len(v) for v in (snap.get("open_orders") or {}).values())
+
+        # Prometheus text format (v0.0.4)
+        lines = []
+        lines.append("# HELP ftm2_uptime_seconds Process uptime in seconds")
+        lines.append("# TYPE ftm2_uptime_seconds gauge")
+        lines.append(f"ftm2_uptime_seconds {uptime}")
+
+        lines.append("# HELP ftm2_equity Account equity")
+        lines.append("# TYPE ftm2_equity gauge")
+        lines.append(f"ftm2_equity {equity}")
+
+        lines.append("# HELP ftm2_leverage Notional / Equity")
+        lines.append("# TYPE ftm2_leverage gauge")
+        # 레버리지 계산
+        notional = 0.0
+        for sym, p in (snap.get("positions") or {}).items():
+            qty = float(p.get("pa") or 0.0)
+            px = float((snap.get("marks") or {}).get(sym, {}).get("price") or 0.0)
+            notional += abs(qty) * px
+        lever = (notional / equity) if equity > 0 else 0.0
+        lines.append(f"ftm2_leverage {lever}")
+
+        lines.append("# HELP ftm2_open_orders Current open orders")
+        lines.append("# TYPE ftm2_open_orders gauge")
+        lines.append(f"ftm2_open_orders {open_orders}")
+
+        lines.append("# HELP ftm2_exec_slip_bps_p90 Rolling p90 slippage (bps)")
+        lines.append("# TYPE ftm2_exec_slip_bps_p90 gauge")
+        p90 = float((eq.get("slip_bps_overall") or {}).get("p90") or 0.0)
+        lines.append(f"ftm2_exec_slip_bps_p90 {p90}")
+
+        lines.append("# HELP ftm2_orders_total Orders in window")
+        lines.append("# TYPE ftm2_orders_total gauge")
+        lines.append(f"ftm2_orders_total {int(ol.get('orders') or 0)}")
+
+        lines.append("# HELP ftm2_fill_rate Fill rate in window")
+        lines.append("# TYPE ftm2_fill_rate gauge")
+        lines.append(f"ftm2_fill_rate {float(ol.get('fill_rate') or 0.0)}")
+
+        return self._write(200, "\n".join(lines) + "\n", content_type="text/plain; version=0.0.4")
+
+    def _kpi(self):
+        snap = self.bus.snapshot() if self.bus else {}
+        kpi = (snap.get("monitor") or {}).get("kpi") or {}
+        return self._write(200, json.dumps(kpi, ensure_ascii=False), content_type="application/json; charset=utf-8")
+
+class OpsHTTPD:
+    def __init__(self, bus: StateBus, cfg: OpsHttpConfig) -> None:
+        self.bus = bus
+        self.cfg = cfg
+        self._th: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._server: Optional[HTTPServer] = None
+
+    def start(self) -> None:
+        if not self.cfg.enabled:
+            log.info("[OPS_HTTP] disabled")
+            return
+        if self._th and self._th.is_alive():
+            return
+        _Handler.bus = self.bus
+        _Handler.cfg = self.cfg
+        self._server = HTTPServer((self.cfg.host, int(self.cfg.port)), _Handler)
+        self._stop.clear()
+        def _serve():
+            log.info("[OPS_HTTP] start on %s:%s", self.cfg.host, self.cfg.port)
+            try:
+                while not self._stop.is_set():
+                    self._server.handle_request()
+            except Exception as e:
+                log.warning("[OPS_HTTP][ERR] %s", e)
+            log.info("[OPS_HTTP] stop")
+        self._th = threading.Thread(target=_serve, name="ops-http", daemon=True)
+        self._th.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        # 더미 요청으로 깨어나게 할 수도 있으나, 데몬 스레드이므로 생략

--- a/ftm2/strategy/adapter.py
+++ b/ftm2/strategy/adapter.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+Strategy Adapter
+- 실전 ForecastEnsemble ↔ 오프라인 러너(백테스트/리플레이) 연결 계층
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Any, Optional, List, Tuple, Protocol
+import importlib, json, math, logging
+from collections import deque, defaultdict
+
+log = logging.getLogger("ftm2.strat")
+if not log.handlers:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+class StrategyAdapterBase(Protocol):
+    def infer(self, snapshot: Dict[str, Any], symbols: List[str], interval: str) -> Dict[str, Dict[str, Any]]:
+        ...
+
+# --- 더미(모멘텀 EMA) ---
+class DummyMomentumAdapter:
+    """
+    입력: snapshot.features[(sym,interval)]에 c(종가), c_prev 가 있으면 log return 누적
+    출력: {sym: {"stance": LONG/SHORT/FLAT, "score": [-1..1]}}
+    """
+    def __init__(self, lookback: int = 12, scale: float = 10.0) -> None:
+        self.lookback = lookback
+        self.scale = scale
+        self._rets: Dict[str, deque] = defaultdict(lambda: deque(maxlen=max(lookback*4, 32)))
+
+    @staticmethod
+    def _ema(prev: Optional[float], x: float, k: float) -> float:
+        return (1-k)*prev + k*x if prev is not None else x
+
+    def infer(self, snapshot: Dict[str, Any], symbols: List[str], interval: str) -> Dict[str, Dict[str, Any]]:
+        feats = snapshot.get("features") or {}
+        k = 2.0 / (self.lookback + 1)
+        out: Dict[str, Dict[str, Any]] = {}
+        for s in symbols:
+            f = feats.get((s, interval), {})
+            c = float(f.get("c") or 0.0)
+            cp = float(f.get("c_prev") or 0.0)
+            r = (math.log(c/cp) if c>0 and cp>0 else 0.0)
+            self._rets[s].append(r)
+            # EMA
+            e = None
+            for x in self._rets[s]:
+                e = self._ema(e, x, k)
+            score = max(-1.0, min(1.0, (e or 0.0) * self.scale))
+            stance = "LONG" if score > 0 else "SHORT" if score < 0 else "FLAT"
+            if abs(score) < 0.05:
+                stance, score = "FLAT", 0.0
+            out[s] = {"stance": stance, "score": score}
+        return out
+
+# --- 실전 ForecastEnsemble 어댑터 ---
+class EnsembleAdapter:
+    """
+    ForecastEnsemble 래핑: ensemble.infer(snapshot) → {(sym,interval): {stance,score}}
+    """
+    def __init__(self, db=None, params: Optional[Dict[str, Any]] = None) -> None:
+        self._ens = None
+        self._err: Optional[str] = None
+        try:
+            try:
+                from ftm2.forecast.ensemble import ForecastEnsemble  # type: ignore
+            except Exception:
+                from forecast.ensemble import ForecastEnsemble        # type: ignore
+            # params가 있으면 생성자에 전달(미호환 시 예외 → 더미 폴백)
+            self._ens = ForecastEnsemble(**(params or {}))
+            log.info("[STRAT] ForecastEnsemble 활성")
+        except Exception as e:
+            self._err = str(e)
+            log.warning("[STRAT][FALLBACK] ensemble 사용 불가 → dummy (%s)", e)
+            self._ens = None
+            self._dummy = DummyMomentumAdapter()
+
+    def infer(self, snapshot: Dict[str, Any], symbols: List[str], interval: str) -> Dict[str, Dict[str, Any]]:
+        if self._ens is None:
+            return self._dummy.infer(snapshot, symbols, interval)
+        res = self._ens.infer(snapshot)  # 기대: {(sym,interval): {...}}
+        out: Dict[str, Dict[str, Any]] = {}
+        for s in symbols:
+            key = (s, interval)
+            rec = res.get(key) or res.get(s) or {}
+            stance = (rec.get("stance") or "FLAT").upper()
+            score = float(rec.get("score") or 0.0)
+            out[s] = {"stance": stance, "score": score}
+        return out
+
+# --- 커스텀 클래스 로딩 ---
+def _import_string(path: str):
+    mod, _, attr = path.rpartition(".")
+    if not mod: raise ImportError(f"Invalid path: {path}")
+    m = importlib.import_module(mod)
+    return getattr(m, attr)
+
+# --- 팩토리 ---
+def create_adapter(mode: str = "dummy", class_path: Optional[str] = None, params: Optional[Dict[str, Any]] = None, db=None) -> StrategyAdapterBase:
+    mode = (mode or "dummy").lower()
+    if mode == "ensemble":
+        return EnsembleAdapter(db=db, params=params)
+    if mode == "custom" and class_path:
+        try:
+            Cls = _import_string(class_path)
+            return Cls(**(params or {}))
+        except Exception as e:
+            log.warning("[STRAT][FALLBACK] custom 로드 실패 → dummy (%s)", e)
+    # default
+    return DummyMomentumAdapter()

--- a/ftm2/tests/test_config.py
+++ b/ftm2/tests/test_config.py
@@ -9,7 +9,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from ftm2.core.config import load_forecast_cfg, load_risk_cfg
+from ftm2.core.config import load_forecast_cfg, load_risk_cfg, load_ops_http_cfg
 from ftm2.signal.forecast import ForecastEnsemble, ForecastConfig
 from ftm2.trade.risk import RiskEngine, RiskConfig
 from ftm2.app import Orchestrator
@@ -45,6 +45,15 @@ def test_load_risk_cfg_priority(monkeypatch):
     assert cfg.risk_target_pct == 0.4
     assert cfg.corr_cap_per_side == 0.5
     assert cfg.atr_k == 2.0
+
+
+def test_load_ops_http_cfg_priority(monkeypatch):
+    monkeypatch.setenv("OPS_HTTP_PORT", "9000")
+    db = DummyDB({"ops.http.enabled": "false"})
+    cfg = load_ops_http_cfg(db)
+    assert cfg.enabled is False
+    assert cfg.port == 9000
+    assert cfg.host == "0.0.0.0"
 
 
 def test_reload_cfg_loop_updates(monkeypatch):

--- a/patch.txt
+++ b/patch.txt
@@ -44,4 +44,9 @@
 - feat(streams): 공개 데이터와 유저스트림 클라이언트 분리 주입 지원
 - feat(app): 하이브리드 결선(live 차트 + testnet 주문) 기본 시나리오 추가
 
+2025-09-19 v0.4.1
+- feat(strategy-adapter): 백테스트/리플레이에 실전 ForecastEnsemble 주입 가능하도록 어댑터 계층 추가(STRAT_MODE/CLASS/PARAMS)
+- feat(backtest): 러너가 어댑터를 통해 예측을 생성하도록 변경(스냅샷 호환 유지)
 
+
+- feat(ops): 운영 HTTP 엔드포인트 추가 — /healthz /readyz /metrics /kpi (Prometheus 호환), ENV/DB 설정 및 앱 결선


### PR DESCRIPTION
## Summary
- add strategy adapter with dummy momentum fallback and ForecastEnsemble support
- allow backtest CLI to load and inject strategy adapter
- expose strategy adapter configuration via core config and .env
- add lightweight ops HTTP server with /healthz, /readyz, /metrics, /kpi endpoints
- load ops HTTP config from env or DB and start server from orchestrator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7edf0c8dc832d84505ac1f74d0ad2