### PR TITLE
feat: add analysis publisher and panel manager

### DIFF
--- a/ftm2/analysis/__init__.py
+++ b/ftm2/analysis/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Analysis helpers"""

--- a/ftm2/analysis/publisher.py
+++ b/ftm2/analysis/publisher.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Discord 실시간 분석 리포트 발행"""
+# [ANCHOR:ANALYSIS_PUB]
+import os, json
+from pathlib import Path
+import logging, asyncio, math, time
+import discord  # type: ignore
+
+
+class AnalysisPublisher:
+    def __init__(self, bot, bus, interval_s=60):
+        self.bot = bot
+        self.bus = bus
+        self.intv = interval_s
+        self.log = logging.getLogger("ftm2.analysis")
+        self._task = None
+        self._path = Path("./runtime/analysis.json")
+        self._msg = None
+
+    async def _ensure_msg(self):
+        ch_id = int(os.getenv("DISCORD_CHANNEL_ID_ANALYSIS", "0") or 0)
+        if not ch_id:
+            raise RuntimeError("DISCORD_CHANNEL_ID_ANALYSIS not set")
+        ch = self.bot.get_channel(ch_id) or await self.bot.fetch_channel(ch_id)
+        mid = None
+        if self._path.exists():
+            try:
+                mid = json.loads(self._path.read_text()).get("mid")
+            except Exception:
+                pass
+        if mid:
+            try:
+                self._msg = await ch.fetch_message(mid)
+                return self._msg
+            except Exception:
+                self._msg = None
+        self._msg = await ch.send("🔎 분석 초기화 중…")
+        try:
+            await self._msg.pin(reason="FTM2 Analysis")
+        except Exception:
+            pass
+        self._path.write_text(json.dumps({"mid": self._msg.id}))
+        return self._msg
+
+    def _fmt_row(self, sym, snap, tfs=("5m","15m","1h","4h")):
+        marks = snap.get("marks", {})
+        regimes = snap.get("regimes", {}).get(sym, {})  # ex) {"5m":"RANGE_HIGH",...}
+        m = marks.get(sym)
+        parts = [f"**{sym}** {m:.4f}" if isinstance(m,(int,float)) else f"**{sym}** -"]
+        label = {"TREND_UP":"📈상승","TREND_DOWN":"📉하락",
+                 "RANGE_HIGH":"🟧박스(고변동)","RANGE_LOW":"🟦박스(저변동)","NONE":"·"}
+        for tf in tfs:
+            r = regimes.get(tf) or "NONE"
+            parts.append(f"{tf}:{label.get(r,r)}")
+        return "  • " + " | ".join(parts)
+
+    def _render(self, snap):
+        syms = snap.get("symbols", [])
+        t = time.strftime("%H:%M:%S", time.gmtime(int(snap.get("now_ts",0))/1000))
+        hdr = f"🧠 **실시간 분석 리포트**  (`{t} UTC`)\n"
+        body = "\n".join(self._fmt_row(s, snap) for s in syms)
+        note = "\n_※ 레짐은 실선물 마크/클라인 기반. 트레이딩은 TESTNET 모드._"
+        return hdr + body + note
+
+    async def _loop(self):
+        await self._ensure_msg()
+        while True:
+            try:
+                snap = self.bot.bus.snapshot() if hasattr(self.bot,"bus") else {}
+                txt = self._render(snap)
+                await self._msg.edit(content=txt)
+                self.log.info("[ANALYSIS] 업데이트 완료")
+            except Exception as e:
+                self.log.warning("[ANALYSIS] 업데이트 오류: %s", e)
+            await asyncio.sleep(self.intv)
+
+    def start(self):
+        if not self._task or self._task.done():
+            self._task = asyncio.create_task(self._loop(), name="analysis-pub")
+
+    def stop(self):
+        if self._task and not self._task.done():
+            self._task.cancel()

--- a/ftm2/discord_bot/panel_manager.py
+++ b/ftm2/discord_bot/panel_manager.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Discord Control Panel pinned message manager"""
+# [ANCHOR:PANEL_MANAGER]
+import json, os, logging
+from pathlib import Path
+import discord  # type: ignore
+
+try:
+    from ftm2.discord_bot.views import ControlPanelView
+except Exception:  # pragma: no cover
+    from discord_bot.views import ControlPanelView  # type: ignore
+
+
+class PanelManager:
+    def __init__(self, bot: discord.Client):
+        self.bot = bot
+        self.log = logging.getLogger("ftm2.panel")
+        self.path = Path("./runtime/panel.json")
+        self._msg = None
+
+    def _load_mid(self):
+        if self.path.exists():
+            try:
+                return json.loads(self.path.read_text(encoding="utf-8")).get("mid")
+            except Exception:
+                pass
+        return None
+
+    def _save_mid(self, mid: int):
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps({"mid": mid}), encoding="utf-8")
+
+    async def ensure_panel_message(self):
+        ch_id = int(os.getenv("DISCORD_CHANNEL_ID_PANEL", "0") or 0)
+        if not ch_id:
+            raise RuntimeError("DISCORD_CHANNEL_ID_PANEL not set")
+        ch = self.bot.get_channel(ch_id) or await self.bot.fetch_channel(ch_id)
+
+        mid = self._load_mid()
+        msg = None
+        if mid:
+            try:
+                msg = await ch.fetch_message(mid)
+                self.log.info("[PANEL] 기존 메시지 재사용(mid=%s)", mid)
+            except Exception:
+                msg = None
+
+        content = (
+            "🎛️ **컨트롤 패널**\n"
+            "• 이 메시지는 고정이며 버튼으로 봇을 제어합니다.\n"
+            "• (입력 명령은 `/panel` 입니다. 표시 명칭은 **패널**)"
+        )
+
+        if msg is None:
+            msg = await ch.send(content, view=ControlPanelView())
+            try:
+                await msg.pin(reason="FTM2 Control Panel")
+            except Exception:
+                pass
+            self._save_mid(msg.id)
+            self.log.info("[PANEL] 신규 생성(mid=%s)", msg.id)
+        else:
+            try:
+                await msg.edit(content=content, view=ControlPanelView())
+            except Exception as e:
+                self.log.warning("[PANEL] edit 실패: %s", e)
+
+        self._msg = msg
+        return msg
+
+    async def refresh(self):
+        if self._msg is None:
+            await self.ensure_panel_message()
+        else:
+            try:
+                await self._msg.edit(view=ControlPanelView())
+            except Exception as e:
+                self.log.warning("[PANEL] refresh 실패: %s", e)
+
+    async def close(self):
+        # 메시지는 남겨두고 View만 떼면 된다(원한다면 pass)
+        try:
+            if self._msg:
+                await self._msg.edit(view=None)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add AnalysisPublisher to post and update a pinned analysis report
- manage a persistent control panel message with PanelManager
- integrate panel and analysis publisher into Discord bot lifecycle

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8f058d2e4832d95d03c13560faaaa