### PR TITLE
fix: unify config table column and exec key

### DIFF
--- a/ftm2/core/config.py
+++ b/ftm2/core/config.py
@@ -280,7 +280,11 @@ def load_exec_cfg(cfg_db) -> _ExecCfgView:
       exec.active, exec.cooldown_s, exec.tol_rel, exec.tol_abs, exec.order_type, exec.reduce_only
     """
 
-    A = _get_db_val(cfg_db, "exec.active") or _get_env_val("EXEC_ACTIVE")
+    A = (
+        _get_db_val(cfg_db, "exec.active")
+        or _get_db_val(cfg_db, "EXEC_ACTIVE")
+        or _get_env_val("EXEC_ACTIVE")
+    )
     CD = _get_db_val(cfg_db, "exec.cooldown_s") or _get_env_val("EXEC_COOLDOWN_S")
     TR = _get_db_val(cfg_db, "exec.tol_rel") or _get_env_val("EXEC_TOL_REL")
     TA = _get_db_val(cfg_db, "exec.tol_abs") or _get_env_val("EXEC_TOL_ABS")

--- a/ftm2/core/persistence.py
+++ b/ftm2/core/persistence.py
@@ -98,7 +98,7 @@ class Persistence:
             """
             CREATE TABLE IF NOT EXISTS config (
               key TEXT PRIMARY KEY,
-              value TEXT,
+              val TEXT,
               updated_at INTEGER
             );
             """,
@@ -159,14 +159,14 @@ class Persistence:
         with self._lock, self._conn:
             for q in ddl:
                 self._conn.execute(q)
-            if not self._col_exists("config", "value"):
-                self._conn.execute("ALTER TABLE config ADD COLUMN value TEXT")
+            if not self._col_exists("config", "val"):
+                self._conn.execute("ALTER TABLE config ADD COLUMN val TEXT")
                 try:
-                    self._conn.execute("UPDATE config SET value = v WHERE value IS NULL")
+                    self._conn.execute("UPDATE config SET val = value WHERE val IS NULL")
                 except sqlite3.OperationalError:
                     pass
                 try:
-                    self._conn.execute("UPDATE config SET value = val WHERE value IS NULL")
+                    self._conn.execute("UPDATE config SET val = v WHERE val IS NULL")
                 except sqlite3.OperationalError:
                     pass
         log.info("[DB] schema ready")
@@ -196,10 +196,10 @@ class Persistence:
         with self._lock, self._conn:
             self._conn.execute(
                 """
-                INSERT INTO config(key, value, updated_at)
+                INSERT INTO config(key, val, updated_at)
                 VALUES (?, ?, ?)
                 ON CONFLICT(key) DO UPDATE SET
-                  value=excluded.value,
+                  val=excluded.val,
                   updated_at=excluded.updated_at
                 """,
                 (key, val, self._now_ms()),
@@ -207,9 +207,9 @@ class Persistence:
 
     def get_config(self, key: str) -> Optional[str]:
         with self._lock:
-            cur = self._conn.execute("SELECT value FROM config WHERE key=?", (key,))
+            cur = self._conn.execute("SELECT val FROM config WHERE key=?", (key,))
             row = cur.fetchone()
-            return row["value"] if row else None
+            return row["val"] if row else None
 
     def save_trade(self, d: Dict[str, Any]) -> None:
         # 필드 기본값 보정

--- a/ftm2/db.py
+++ b/ftm2/db.py
@@ -18,18 +18,14 @@ def init_db(db_path: str = "./runtime/trader.db") -> sqlite3.Connection:
         """
         CREATE TABLE IF NOT EXISTS config (
             key TEXT PRIMARY KEY
-            -- value column is added below if missing
+            -- val column is added below if missing
         )
         """
     )
-    if not _col_exists(conn, "config", "value"):
-        conn.execute("ALTER TABLE config ADD COLUMN value TEXT")
+    if not _col_exists(conn, "config", "val"):
+        conn.execute("ALTER TABLE config ADD COLUMN val TEXT")
         try:
-            conn.execute("UPDATE config SET value = v WHERE value IS NULL")
-        except sqlite3.OperationalError:
-            pass
-        try:
-            conn.execute("UPDATE config SET value = val WHERE value IS NULL")
+            conn.execute("UPDATE config SET val = value WHERE val IS NULL")
         except sqlite3.OperationalError:
             pass
         conn.commit()

--- a/ftm2/discord_bot/views.py
+++ b/ftm2/discord_bot/views.py
@@ -15,8 +15,8 @@ def _db_path() -> str:
 def set_exec_active(conn, is_on: bool, source: str):
     conn.execute(
         """
-        INSERT INTO config(key, value) VALUES('EXEC_ACTIVE', ?)
-        ON CONFLICT(key) DO UPDATE SET value=excluded.value
+        INSERT INTO config(key, val) VALUES('exec.active', ?)
+        ON CONFLICT(key) DO UPDATE SET val=excluded.val
         """,
         ("1" if is_on else "0",),
     )

--- a/ftm2/tests/test_persistence.py
+++ b/ftm2/tests/test_persistence.py
@@ -20,7 +20,7 @@ def test_persistence_basic(tmp_path):
     with sqlite3.connect(db_path) as conn:
         assert conn.execute("select count(*) from events").fetchone()[0] == 1
         assert conn.execute("select count(*) from patches").fetchone()[0] == 1
-        assert conn.execute("select value from config where key='k'").fetchone()[0] == "v2"
+        assert conn.execute("select val from config where key='k'").fetchone()[0] == "v2"
         assert conn.execute("select count(*) from trades").fetchone()[0] == 1
         assert conn.execute("select qty from positions where symbol='BTCUSDT'").fetchone()[0] == 2.0
 


### PR DESCRIPTION
## Summary
- use `val` column in config table across dashboard, bot views and persistence
- record exec toggle under `exec.active` and allow `EXEC_ACTIVE` fallback
- update schema helpers and tests for new column name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9320110e8832d961f1b4d5eca2d2d