### PR TITLE
feat(exchange): add auto trade mode and key detection

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -251,9 +251,10 @@ class Orchestrator:
             pass
 
         modes = load_modes_cfg(self.db)
+        exv = load_exec_cfg(self.db)
         # [ANCHOR:DUAL_MODE]
         self.cli_data = BinanceClient.for_data(modes.data_mode)
-        self.cli_trade = BinanceClient.for_trade(modes.trade_mode, order_active=True)
+        self.cli_trade = BinanceClient.for_trade(modes.trade_mode, order_active=exv.active)
         self.streams = StreamManager(
             self.cli_data,
             None if modes.trade_mode == "dry" else self.cli_trade,
@@ -291,7 +292,6 @@ class Orchestrator:
             ),
         )
 
-        exv = load_exec_cfg(self.db)
         self.exec_router = OrderRouter(
             self.cli_trade,
             ExecConfig(

--- a/ftm2/core/config.py
+++ b/ftm2/core/config.py
@@ -679,7 +679,7 @@ def load_backtest_cfg(cfg_db) -> _BacktestCfgView:
 @dataclass
 class _ModesCfgView:
     data_mode: str   # live | testnet | replay
-    trade_mode: str  # dry  | testnet | live
+    trade_mode: str  # dry  | testnet | live | auto
 
 
 # [ANCHOR:DUAL_MODE]
@@ -704,10 +704,10 @@ def load_modes_cfg(cfg_db) -> _ModesCfgView:
         return v if v not in (None, "") else d
 
     dm = (gdb("modes.data") or genv("DATA_MODE") or "live").lower()
-    tm = (gdb("modes.trade") or genv("TRADE_MODE") or "dry").lower()
+    tm = (gdb("modes.trade") or genv("TRADE_MODE") or "auto").lower()
     if dm not in ("live", "testnet", "replay"):
         dm = "live"
-    if tm not in ("dry", "testnet", "live"):
-        tm = "dry"
+    if tm not in ("dry", "testnet", "live", "auto"):
+        tm = "auto"
     return _ModesCfgView(dm, tm)
 


### PR DESCRIPTION
## Summary
- allow TRADE_MODE `auto` with default in config
- add unified key loading and automatic env detection in `BinanceClient`
- create trade client with exec activity and pass through configured mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba419d1524832d87e1007c332e97d6