### PR TITLE
feat: sync binance futures account balances and positions

### DIFF
--- a/ftm2/app.py
+++ b/ftm2/app.py
@@ -205,7 +205,44 @@ def init_account_bus(bus) -> None:
         return
 
     log.info("[ACCOUNT] scope=%s key=%s secret=%s", scope, _mask(k), _mask(s))
-    # TODO: 실제 연결/폴링 start
+
+    # 계정/포지션 초기화
+    try:
+        cli = BinanceClient(scope, k or "", s or "", order_active=False)
+        try:
+            cli.sync_time()
+        except Exception:
+            pass
+
+        eq = cli.fetch_account_equity()
+        if eq:
+            bus.set_account({
+                "ccy": "USDT",
+                "totalWalletBalance": eq.get("wallet", 0.0),
+                "availableBalance": eq.get("avail", 0.0),
+                "totalUnrealizedProfit": eq.get("upnl", 0.0),
+                "totalMarginBalance": eq.get("equity", 0.0),
+                "wallet": eq.get("wallet", 0.0),
+                "avail": eq.get("avail", 0.0),
+                "upnl": eq.get("upnl", 0.0),
+                "equity": eq.get("equity", 0.0),
+            })
+            log.info(
+                "[ACCOUNT_INIT] wallet=%.2f equity=%.2f upnl=%.2f avail=%.2f",
+                eq.get("wallet", 0.0),
+                eq.get("equity", 0.0),
+                eq.get("upnl", 0.0),
+                eq.get("avail", 0.0),
+            )
+
+        syms = env_list("SYMBOLS") or []
+        if syms:
+            pos = cli.fetch_positions(syms)
+            if pos:
+                bus.set_positions(pos)
+                log.info("[ACCOUNT_INIT] positions loaded n=%d", len(pos))
+    except Exception as e:
+        log.warning("[ACCOUNT_INIT] failed: %s", e)
 # [ANCHOR:KEY_SELECT] end
 
 
@@ -253,7 +290,8 @@ class Orchestrator:
         modes = load_modes_cfg(self.db)
         exv = load_exec_cfg(self.db)
         # [ANCHOR:DUAL_MODE]
-        self.cli_data = BinanceClient.for_data(modes.data_mode)
+        # 시세 스트림은 항상 라이브 사용
+        self.cli_data = BinanceClient.for_data("live")
         self.cli_trade = BinanceClient.for_trade(modes.trade_mode, order_active=exv.active)
         self.streams = StreamManager(
             self.cli_data,
@@ -1122,6 +1160,31 @@ class Orchestrator:
 
     def _heartbeat(self, period_s: int = 10) -> None:
         while not self._stop.is_set():
+            # 계정/포지션 주기 갱신
+            try:
+                eqd = self.cli_trade.fetch_account_equity()
+                if eqd:
+                    self.bus.set_account({
+                        "ccy": "USDT",
+                        "totalWalletBalance": eqd.get("wallet", 0.0),
+                        "availableBalance": eqd.get("avail", 0.0),
+                        "totalUnrealizedProfit": eqd.get("upnl", 0.0),
+                        "totalMarginBalance": eqd.get("equity", 0.0),
+                        "wallet": eqd.get("wallet", 0.0),
+                        "avail": eqd.get("avail", 0.0),
+                        "upnl": eqd.get("upnl", 0.0),
+                        "equity": eqd.get("equity", 0.0),
+                    })
+                    log.info("[EQUITY] updated: totalMarginBalance=%.2f src=ACCOUNT", eqd.get("equity", 0.0))
+            except Exception as e:
+                log.warning("E_EQUITY_POLL_FAIL %s", e)
+            try:
+                pos = self.cli_trade.fetch_positions(self.symbols)
+                if pos:
+                    self.bus.set_positions(pos)
+            except Exception:
+                pass
+
             snap = self.bus.snapshot()
             marks = snap["marks"]
             lines = []

--- a/ftm2/core/env.py
+++ b/ftm2/core/env.py
@@ -6,7 +6,11 @@
 """
 from __future__ import annotations
 import os
-from typing import Dict, Tuple
+import time
+from dataclasses import dataclass
+from typing import Dict, Tuple, Optional
+
+import httpx
 
 # [ANCHOR:ENV_LOADER]
 def _parse_env_file(path: str) -> Dict[str, str]:
@@ -40,3 +44,82 @@ def load_env_chain(paths: Tuple[str, ...] = ("token.env", ".env")) -> Dict[str, 
                 env.setdefault(k, v)
 
     return env
+
+
+# ---- Binance unified credential loader -----------------------------------
+# REST / WS base endpoints
+BINANCE_LIVE_REST = "https://fapi.binance.com"
+BINANCE_TEST_REST = "https://testnet.binancefuture.com"
+BINANCE_LIVE_WS_USTREAM = "wss://fstream.binance.com/ws"
+BINANCE_TEST_WS_USTREAM = "wss://stream.binancefuture.com/ws"
+
+_ENV_CACHE: Optional[Tuple[str, float]] = None  # (env, ts)
+
+
+def _first(*names: str) -> Optional[str]:
+    for n in names:
+        v = os.getenv(n) or os.getenv(n.lower())
+        if v:
+            return v.strip()
+    return None
+
+
+@dataclass
+class BinanceCreds:
+    api_key: str
+    api_secret: str
+    env: str                 # "live" or "testnet"
+    rest_base: str
+    ustream_ws: str          # userDataStream ws base
+
+
+def detect_binance_env(api_key: str, api_secret: str) -> str:
+    """Detect live/testnet automatically by pinging the REST endpoint."""
+    global _ENV_CACHE
+    now = time.time()
+    if _ENV_CACHE and now - _ENV_CACHE[1] < 3600:
+        return _ENV_CACHE[0]
+
+    def _ok(base: str) -> bool:
+        try:
+            with httpx.Client(timeout=3.0) as c:
+                r = c.get(f"{base}/fapi/v1/ping")
+                return r.status_code == 200
+        except Exception:
+            return False
+
+    env = "live" if _ok(BINANCE_LIVE_REST) else "testnet"
+    _ENV_CACHE = (env, now)
+    return env
+
+
+def load_binance_credentials() -> BinanceCreds:
+    """Load API credentials and determine environment.
+
+    Order of precedence:
+    1) BINANCE_ENV or USE_TESTNET to force selection
+    2) automatic detection via REST ping
+    Fallback key names: BINANCE_API_KEY|BINANCE_KEY|FUTURES_API_KEY|TOKEN
+    and BINANCE_API_SECRET|BINANCE_SECRET|FUTURES_API_SECRET
+    """
+
+    api_key = _first("BINANCE_API_KEY", "BINANCE_KEY", "FUTURES_API_KEY", "TOKEN")
+    api_secret = _first("BINANCE_API_SECRET", "BINANCE_SECRET", "FUTURES_API_SECRET")
+    if not api_key or not api_secret:
+        raise RuntimeError(
+            "BINANCE API key/secret not found in env (checked BINANCE_API_KEY/SECRET, TOKEN, ...)."
+        )
+
+    env_hint = _first("BINANCE_ENV")
+    use_testnet = _first("USE_TESTNET")
+    if env_hint:
+        env = "testnet" if env_hint.lower().startswith("test") else "live"
+    elif use_testnet:
+        env = "testnet" if use_testnet.lower() in ("1", "true", "yes", "y") else "live"
+    else:
+        env = detect_binance_env(api_key, api_secret)
+
+    if env == "testnet":
+        return BinanceCreds(api_key, api_secret, env, BINANCE_TEST_REST, BINANCE_TEST_WS_USTREAM)
+    return BinanceCreds(api_key, api_secret, env, BINANCE_LIVE_REST, BINANCE_LIVE_WS_USTREAM)
+


### PR DESCRIPTION
## Summary
- add unified Binance credential loader with automatic live/testnet detection
- read equity and positions from `/fapi/v2/account` and poll them during heartbeat
- always stream market data from live endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5efcb2f8832d92691657a1e5d8ac