### PR TITLE
feat: enhance analysis reporting and position polling

### DIFF
--- a/ftm2/dashboard.py
+++ b/ftm2/dashboard.py
@@ -185,6 +185,20 @@ def render_dashboard(snapshot: Dict[str, Any]) -> str:
             f"{bar}",
             "",
         ]
+    # 포지션 상세(있을 때만)
+    pos = snapshot.get("positions") or {}
+    if pos:
+        lines.append("📦 포지션 상세")
+        for s, p in pos.items():
+            qty = float(p.get("pa") or 0.0)
+            side = "LONG" if qty > 0 else "SHORT"
+            ep = float(p.get("ep") or 0.0)
+            lev = float(p.get("leverage") or 0.0)
+            mp = float((snapshot.get("marks") or {}).get(s, {}).get("price") or 0.0)
+            up = float(p.get("up") or (qty*(mp-ep)))
+            lines.append(f"  • {s:<7} {side:<5} {abs(qty):.6f} @ {ep:,.2f}  | mark {mp:,.2f}  UPNL {up:+.2f}  lev {lev:.0f}x")
+        lines.append("")
+
     # 마크프라이스 요약(기존 로직 유지)
     marks = snapshot.get("marks") or {}
     if marks:

--- a/patch.txt
+++ b/patch.txt
@@ -109,4 +109,10 @@
 - feat(orch): TRADE_MODE별 API 키 선택 및 계정 초기화 로그
 
 
+2025-09-08 v0.6.1
+- feat(analysis): TF별 점수/확률/레짐/기여도·지표 포함한 실시간 분석 리포트 고도화
+- feat(orch): 포지션 폴링 루프 추가(POSITIONS_POLL_SEC) — UserStream 없이도 포지션 갱신
+- feat(exec-toggle): 컨트롤패널 ON 시 BinanceClient.order_active 동기화(의도만 → 실주문)
+- feat(kpi): 대시보드에 포지션 상세 테이블 추가 및 레버리지 표기 개선
+
 


### PR DESCRIPTION
## Summary
- enrich analysis report with per-timeframe scores, probabilities, regimes, features and component contributions
- add positions polling loop and thread to keep bus updated even without user stream
- sync BinanceClient order_active when execution toggle is switched on
- show detailed position table in dashboard; document new feature in patch log

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be2a248e1c832d9ecfcf0e429b4dfb