### PR TITLE
feat: refine equity polling and Korean analysis report

### DIFF
--- a/ftm2/dashboard.py
+++ b/ftm2/dashboard.py
@@ -164,12 +164,17 @@ def render_dashboard(snapshot: Dict[str, Any]) -> str:
             except Exception:
                 pass
 
+        eq_snap = snapshot.get("equity", {}) or {}
+        wallet = float(eq_snap.get("wallet", 0.0))
+        avail = float(eq_snap.get("available", 0.0))
+        port_lev = float(mon.get("portfolio_leverage", 0.0))
+
         lines += [
             "📊 **FTM2 KPI 대시보드**",
             f"{bar}",
             f"⏱️ 가동시간: **{up_min}분**",
 
-            f"💰 자본(Equity): **{_fmt(kpi.get('equity'))}**  레버리지: **{_fmt(kpi.get('lever'))}x**",
+            f"💰 자본(Equity): {wallet:,.2f}  | 사용가능: {avail:,.2f}  | 포트 레버리지: {port_lev:.2f}x",
             f"📈 포지션: {len(pos)}개  UPNL: {upnl:,.2f} USDT",
             f"📉 당일손익: **{_fmt(kpi.get('day_pnl_pct'))}%**  " + ("🛑 데일리컷" if kpi.get("day_cut") else "✅ 정상"),
             "",
@@ -185,6 +190,20 @@ def render_dashboard(snapshot: Dict[str, Any]) -> str:
             f"{bar}",
             "",
         ]
+    # 포지션 상세(있을 때만)
+    pos = snapshot.get("positions") or {}
+    if pos:
+        lines.append("📦 포지션 상세")
+        for s, p in pos.items():
+            qty = float(p.get("pa") or 0.0)
+            side = "LONG" if qty > 0 else "SHORT"
+            ep = float(p.get("ep") or 0.0)
+            lev = float(p.get("leverage") or 0.0)
+            mp = float((snapshot.get("marks") or {}).get(s, {}).get("price") or 0.0)
+            up = float(p.get("up") or (qty*(mp-ep)))
+            lines.append(f"  • {s:<7} {side:<5} {abs(qty):.6f} @ {ep:,.2f}  | mark {mp:,.2f}  UPNL {up:+.2f}  lev {lev:.0f}x")
+        lines.append("")
+
     # 마크프라이스 요약(기존 로직 유지)
     marks = snapshot.get("marks") or {}
     if marks:

--- a/patch.txt
+++ b/patch.txt
@@ -109,4 +109,17 @@
 - feat(orch): TRADE_MODE별 API 키 선택 및 계정 초기화 로그
 
 
+2025-09-08 v0.6.1
+- feat(analysis): TF별 점수/확률/레짐/기여도·지표 포함한 실시간 분석 리포트 고도화
+- feat(orch): 포지션 폴링 루프 추가(POSITIONS_POLL_SEC) — UserStream 없이도 포지션 갱신
+- feat(exec-toggle): 컨트롤패널 ON 시 BinanceClient.order_active 동기화(의도만 → 실주문)
+- feat(kpi): 대시보드에 포지션 상세 테이블 추가 및 레버리지 표기 개선
+
+2025-09-08 v0.6.2
+- feat(connector): Futures ACCOUNT 기반 Equity/Available 산출 (/fapi/v2/account)
+- feat(orch): 의도 더미(INTENT_DUMMY) 기본 OFF, 패널 ON 시 실주문 라우팅 고정
+- feat(analysis): 한글 리포트 — EMA/RV20/ATR/RET1/레짐·기여도 출력
+- feat(kpi): 대시보드 ‘사용가능’ 잔고 추가, 포지션 상세 표기 개선
+- feat(loops): Equity/Positions 폴링 중복 방지 가드
+
 


### PR DESCRIPTION
## Summary
- use Futures ACCOUNT endpoint to track wallet and available balances accurately
- sync execution toggle with Binance client, guard loops, and filter out dummy intents unless enabled
- render full Korean analysis report with EMA/RV20/ATR/RET1 metrics and show available funds on dashboard

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be2a248e1c832d9ecfcf0e429b4dfb