### PR TITLE
feat: expand feature pipeline with regime-aware scoring

### DIFF
--- a/ftm2/analysis/report.py
+++ b/ftm2/analysis/report.py
@@ -1,27 +1,119 @@
-"""Analysis report rendering utilities."""
-
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Any, Dict
+import json
 
 
-def render_brief(symbol: str, tf: str, fc: Dict[str, Any], regime: str, feats: Dict[str, Any]) -> str:
-    """Render a short explanation for forecast output."""
+def _pct(x: float) -> str:
+    try:
+        return f"{x * 100:.2f}%"
+    except Exception:
+        return "-"
 
-    ex = fc.get("explain", {})
-    parts = []
-    if ex:
-        parts.append(f"모멘텀:{ex.get('mom', 0):+.2f}")
-        parts.append(f"평균회귀:{ex.get('meanrev', 0):+.2f}")
-        parts.append(f"돌파:{ex.get('breakout', 0):+.2f}")
-        parts.append(f"변동성:{ex.get('vol', 0):+.2f}")
-        parts.append(f"레짐:{ex.get('regime', 0):+.2f}")
-    meta = f"r={regime} p_up={fc.get('p_up', 0):.3f}"
-    feat_snip = (
-        f"ema={feats.get('ema', 0):+.5f} rv%={feats.get('rv_pr', 0):.3f} atr={feats.get('atr', 0):.2f}"
+
+def _ensure_dict(regime: Any) -> Dict[str, Any]:
+    if isinstance(regime, dict):
+        return regime
+    if isinstance(regime, str):
+        parts = regime.split(";")
+        trend = parts[0].replace("TREND_", "") if parts else regime
+        vol = parts[1].replace("VOL_", "") if len(parts) > 1 else "LOW"
+        return {"code": regime, "trend": trend, "vol": vol}
+    return {"code": "TREND_FLAT", "trend": "FLAT", "vol": "LOW"}
+
+
+def _trace_json_like(d: Dict[str, Any]) -> str:
+    keep = [
+        "symbol",
+        "tf",
+        "score",
+        "p_up",
+        "stance",
+        "readiness",
+        "gates",
+        "plan",
+        "horizon_k",
+    ]
+    compact = {k: d[k] for k in keep if k in d}
+    return json.dumps(compact, ensure_ascii=False, separators=(",", ": "))
+
+
+# [ANCHOR:REPORT_BRIEF]
+def render_brief(*args: Any, **kwargs: Any) -> str:
+    """Render Discord-friendly brief for forecast outputs.
+
+    Supports both the legacy signature ``(symbol, tf, fc, regime, feats)`` and the
+    new ``(forecast_dict, regime_dict)`` form.
+    """
+
+    if args and isinstance(args[0], dict):
+        fx = args[0]
+        regime_input = args[1] if len(args) > 1 else kwargs.get("regime_4h")
+    elif len(args) >= 5:
+        symbol, tf, fc, regime, feats = args[:5]
+        fx = dict(fc)
+        fx.setdefault("symbol", symbol)
+        fx.setdefault("tf", tf)
+        fx.setdefault("score", fc.get("score", 0.0))
+        fx.setdefault("stance", fc.get("stance", "FLAT"))
+        fx.setdefault("readiness", fc.get("readiness", "SCOUT"))
+        fx.setdefault("p_up", fc.get("p_up", 0.5))
+        fx.setdefault("horizon_k", fc.get("horizon_k", 12))
+        fx.setdefault("explain", fc.get("explain", {}))
+        fx.setdefault(
+            "plan",
+            {
+                "entry": "market",
+                "size_qty_est": None,
+                "notional_est": None,
+                "sl": feats.get("atr", 1.5) if isinstance(feats, dict) else 1.5,
+                "tp_ladder": [1.0, 2.0, 3.0],
+            },
+        )
+        regime_input = regime
+    else:
+        raise TypeError("render_brief expects either (forecast, regime) or legacy signature")
+
+    regime_dict = _ensure_dict(regime_input)
+    sym = fx.get("symbol", "?")
+    k = fx.get("horizon_k", 12)
+    p_up = fx.get("p_up", 0.5)
+    score = fx.get("score", 0.0)
+    readiness = fx.get("readiness", "SCOUT")
+    stance = fx.get("stance", "FLAT")
+
+    rv_pr = regime_dict.get("rv_pr")
+    if isinstance(rv_pr, (int, float)):
+        rv_txt = f"RV% {int(round(rv_pr * 100))}"
+    else:
+        rv_txt = "RV% ?"
+    code = regime_dict.get("code") or f"TREND_{regime_dict.get('trend', 'FLAT')}"
+    label = regime_dict.get("label", "〰️")
+    reg_line = f"4h: {code} / {rv_txt}  {label}"
+
+    ex = fx.get("explain", {})
+    mom = ex.get("mom", 0.0)
+    brk = ex.get("breakout", 0.0)
+    mr = ex.get("meanrev", 0.0)
+    vol = ex.get("vol", 0.0)
+    regc = ex.get("regime", 0.0)
+
+    plan = fx.get("plan", {})
+    entry = plan.get("entry", "market")
+    size_est = plan.get("size_qty_est", "?")
+    notion_est = plan.get("notional_est", "?")
+    sl = plan.get("sl", 1.5)
+    tp_ladder = plan.get("tp_ladder", [1.0, 2.0, 3.0])
+
+    head = (
+        f"{sym} — {reg_line}\n"
+        f"핵심(5m, k={k}): P(상승)={_pct(p_up)}  점수:{score:+.2f}  준비상태:{readiness}  [{stance}]"
     )
-    return (
-        f"{symbol} [{tf}] 점수:{fc['score']:+.2f} / 방향:{fc['stance']} | {meta}\n"
-        f"  - 기여도: " + " ".join(parts) + f"\n  - 특성: {feat_snip}"
+    body = (
+        f"• 설명: 모멘텀 {mom:+.2f}, 돌파 {brk:+.2f}, 평균회귀 {mr:+.2f}, 변동성 {vol:+.2f}, 레짐 {regc:+.2f}\n"
+        f"• 계획: {entry} 진입, 크기 ~{size_est} (= {notion_est}), SL {sl}×ATR, TP {','.join(str(x) for x in tp_ladder)}R\n"
+        f"• 보호: BE 승격/트레일 on, 쿨다운 L=5m / 15m / 1h / 4h\n"
+        f"▼ trace\n{_trace_json_like(fx)}"
     )
+    return head + "\n" + body
 

--- a/ftm2/data/features.py
+++ b/ftm2/data/features.py
@@ -101,13 +101,78 @@ def percentile_rank(sorted_vals: List[float], x: float) -> float:
     return rank / n
 
 
+def _wilder_smooth(vals: List[float], n: int) -> List[float]:
+    if n <= 0 or len(vals) < n:
+        return []
+    window = vals[:n]
+    avg = sum(window) / n
+    out: List[float] = [avg]
+    for v in vals[n:]:
+        avg = ((avg * (n - 1)) + v) / n
+        out.append(avg)
+    return out
+
+
+def _calc_adx(highs: List[float], lows: List[float], closes: List[float], n: int) -> float:
+    if n <= 0 or len(closes) <= n:
+        return 0.0
+    dm_p: List[float] = []
+    dm_m: List[float] = []
+    tr: List[float] = []
+    for i in range(1, len(closes)):
+        up = highs[i] - highs[i - 1]
+        dn = lows[i - 1] - lows[i]
+        dm_p.append(up if up > dn and up > 0 else 0.0)
+        dm_m.append(dn if dn > up and dn > 0 else 0.0)
+        tr.append(max(highs[i] - lows[i], abs(highs[i] - closes[i - 1]), abs(lows[i] - closes[i - 1])))
+    tr_s = _wilder_smooth(tr, n)
+    dm_p_s = _wilder_smooth(dm_p, n)
+    dm_m_s = _wilder_smooth(dm_m, n)
+    if not tr_s or not dm_p_s or not dm_m_s:
+        return 0.0
+    di_p: List[float] = []
+    di_m: List[float] = []
+    for i in range(len(tr_s)):
+        denom = tr_s[i]
+        if denom == 0:
+            di_p.append(0.0)
+            di_m.append(0.0)
+        else:
+            di_p.append(100.0 * dm_p_s[i] / denom)
+            di_m.append(100.0 * dm_m_s[i] / denom)
+    dx: List[float] = []
+    for i in range(len(di_p)):
+        denom = di_p[i] + di_m[i]
+        if denom == 0:
+            dx.append(0.0)
+        else:
+            dx.append(100.0 * abs(di_p[i] - di_m[i]) / denom)
+    adx = _wilder_smooth(dx, n)
+    return adx[-1] if adx else 0.0
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.getenv(key)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except Exception:
+        return default
+
+
 @dataclass
 class FeatureConfig:
-    ema_fast: int = 12
-    ema_slow: int = 26
-    atr_n: int = 14
+    ema_fast: int = _env_int("FE_EMA_FAST", 20)
+    ema_slow: int = _env_int("FE_EMA_SLOW", 50)
+    ema_long: int = _env_int("FE_EMA_LONG", 200)
+    atr_n: int = _env_int("FE_WIN_ATR", 14)
     rsi_n: int = 14
-    rv_n: int = 20
+    rv_n: int = _env_int("FE_WIN_RV", 20)
+    bb_n: int = _env_int("FE_BB_WIN", 20)
+    donch_n: int = _env_int("FE_DON_WIN", 20)
+    adx_n: int = 14
+    slope_k: int = 5
     # 퍼센타일 캐시 길이
     pr_n: int = 240
     # 수익률 lookbacks
@@ -117,20 +182,48 @@ class FeatureConfig:
 class TAState:
     """심볼×인터벌별 누적 상태"""
     __slots__ = (
-        "prev_c", "ema_f", "ema_s",
-        "atr", "rsi_ag", "rsi_al",
-        "closes", "rets", "trs"
+        "prev_c",
+        "prev_h",
+        "prev_l",
+        "ema_f",
+        "ema_s",
+        "ema_l",
+        "ema_f_hist",
+        "ema_s_hist",
+        "ema_l_hist",
+        "atr",
+        "rsi_ag",
+        "rsi_al",
+        "closes",
+        "rets",
+        "trs",
+        "highs",
+        "lows",
+        "dm_p",
+        "dm_m",
+        "tr_raw",
     )
     def __init__(self, cfg: FeatureConfig) -> None:
         self.prev_c: Optional[float] = None
+        self.prev_h: Optional[float] = None
+        self.prev_l: Optional[float] = None
         self.ema_f: Optional[float] = None
         self.ema_s: Optional[float] = None
+        self.ema_l: Optional[float] = None
+        self.ema_f_hist = RollingSeries(maxlen=400)
+        self.ema_s_hist = RollingSeries(maxlen=400)
+        self.ema_l_hist = RollingSeries(maxlen=800)
         self.atr: Optional[float] = None
         self.rsi_ag: Optional[float] = None  # avg gain
         self.rsi_al: Optional[float] = None  # avg loss
-        self.closes = RollingSeries(maxlen=max(cfg.rv_n, 300))
-        self.rets = RollingSeries(maxlen=300)
-        self.trs = RollingSeries(maxlen=max(cfg.atr_n, 300))
+        self.closes = RollingSeries(maxlen=max(cfg.rv_n, cfg.bb_n, cfg.donch_n, 400))
+        self.rets = RollingSeries(maxlen=400)
+        self.trs = RollingSeries(maxlen=max(cfg.atr_n, 400))
+        self.highs = RollingSeries(maxlen=max(cfg.donch_n, 400))
+        self.lows = RollingSeries(maxlen=max(cfg.donch_n, 400))
+        self.dm_p = RollingSeries(maxlen=max(cfg.adx_n * 2, 400))
+        self.dm_m = RollingSeries(maxlen=max(cfg.adx_n * 2, 400))
+        self.tr_raw = RollingSeries(maxlen=max(cfg.adx_n * 2, 400))
 
     def update_bar(self, o: float, h: float, l: float, c: float, cfg: FeatureConfig) -> Dict[str, float]:
         """닫힌 봉 입력 → 상태 업데이트 & 기본 피처 일부 즉시 산출(EMA/ATR/RSI/ret1)"""
@@ -151,6 +244,13 @@ class TAState:
 
         self.ema_f = _ema_step(self.ema_f, c, cfg.ema_fast)
         self.ema_s = _ema_step(self.ema_s, c, cfg.ema_slow)
+        self.ema_l = _ema_step(self.ema_l, c, cfg.ema_long)
+        if self.ema_f is not None:
+            self.ema_f_hist.append(float(self.ema_f))
+        if self.ema_s is not None:
+            self.ema_s_hist.append(float(self.ema_s))
+        if self.ema_l is not None:
+            self.ema_l_hist.append(float(self.ema_l))
 
         # TR/ATR (Wilder)
         if self.prev_c is None:
@@ -158,12 +258,26 @@ class TAState:
         else:
             tr = max(h - l, abs(h - self.prev_c), abs(l - self.prev_c))
         self.trs.append(tr)
+        self.tr_raw.append(tr)
         if self.atr is None:
             # 초기 시드: n개 평균(충분히 쌓이면 자연히 수렴)
             if len(self.trs) >= cfg.atr_n:
                 self.atr = sum(self.trs.values()[-cfg.atr_n:]) / cfg.atr_n
         else:
             self.atr = (self.atr * (cfg.atr_n - 1) + tr) / cfg.atr_n
+
+        # 히스토리 유지
+        self.highs.append(h)
+        self.lows.append(l)
+        if self.prev_h is not None and self.prev_l is not None:
+            up = h - self.prev_h
+            dn = self.prev_l - l
+            dm_p = up if up > dn and up > 0 else 0.0
+            dm_m = dn if dn > up and dn > 0 else 0.0
+        else:
+            dm_p = dm_m = 0.0
+        self.dm_p.append(dm_p)
+        self.dm_m.append(dm_m)
 
         # RSI (Wilder)
         if self.prev_c is not None:
@@ -186,6 +300,8 @@ class TAState:
 
         # prev close 업데이트
         self.prev_c = c
+        self.prev_h = h
+        self.prev_l = l
 
         # 즉시 산출 값들 반환(나머지는 엔진에서 추가 계산)
         out: Dict[str, float] = {
@@ -193,6 +309,8 @@ class TAState:
             "ema_fast": float(self.ema_f) if self.ema_f is not None else float(c),
             "ema_slow": float(self.ema_s) if self.ema_s is not None else float(c),
         }
+        if self.ema_l is not None:
+            out["ema_long"] = float(self.ema_l)
         if self.atr is not None and self.atr > 0:
             out["atr14"] = float(self.atr)
             out["rng_atr"] = float((h - l) / self.atr)
@@ -330,14 +448,77 @@ class FeatureEngine:
         rv_pr = percentile_rank(sorted(ser.values()), float(rv))
         ret1 = feats.get("ret1", 0.0)
         atr = feats.get("atr14", 0.0)
+        ema_fast = float(feats.get("ema_fast", c))
+        ema_slow = float(feats.get("ema_slow", c))
+        ema_long = float(feats.get("ema_long", ema_slow))
+
+        ema_hist = st.ema_f_hist.values()
+        slope_k = max(1, self.cfg.slope_k)
+        if len(ema_hist) > slope_k:
+            ema_slope = (ema_hist[-1] - ema_hist[-1 - slope_k]) / slope_k
+        else:
+            ema_slope = 0.0
+        ema_spread = 0.0 if ema_slow == 0.0 else (ema_fast - ema_slow) / ema_slow
+        long_spread = 0.0 if ema_long == 0.0 else (ema_slow - ema_long) / ema_long
+
+        closes = st.closes.values()
+        window = closes[-self.cfg.bb_n :] if len(closes) >= 2 else closes
+        if len(window) >= 2:
+            mu = sum(window) / len(window)
+            std = self._std(window)
+            zscore = 0.0 if std == 0.0 else (c - mu) / std
+            bbw = 0.0 if mu == 0.0 else (2.0 * std) / mu
+        else:
+            zscore = 0.0
+            bbw = 0.0
+
+        highs = st.highs.values()
+        lows = st.lows.values()
+        if highs and lows:
+            hi = max(highs[-self.cfg.donch_n :])
+            lo = min(lows[-self.cfg.donch_n :])
+            if hi != lo:
+                donch = ((h - lo) / (hi - lo)) - ((hi - l) / (hi - lo))
+            else:
+                donch = 0.0
+        else:
+            donch = 0.0
+
+        adx = 0.0
+        if highs and lows and closes:
+            min_len = min(len(highs), len(lows), len(closes))
+            if min_len > self.cfg.adx_n:
+                h_seq = highs[-min_len:]
+                l_seq = lows[-min_len:]
+                c_seq = closes[-min_len:]
+                adx = _calc_adx(h_seq, l_seq, c_seq, self.cfg.adx_n)
+
+        ts_val = int(bar.get("T") or 0)
+
+        def _safe(v: float) -> float:
+            try:
+                v_f = float(v)
+            except Exception:
+                v_f = 0.0
+            return v_f if math.isfinite(v_f) else 0.0
+
         out = {
-            "ret1": float(ret1),
-            "rv20": float(rv),
-            "atr": float(atr),
-            "ema_fast": float(feats.get("ema_fast", c)),
-            "ema_slow": float(feats.get("ema_slow", c)),
-            "pr_rv20": float(rv_pr),
-            "ts": int(bar.get("T") or 0),
+            "ret1": _safe(ret1),
+            "rv20": _safe(rv),
+            "atr": _safe(atr),
+            "ema_fast": _safe(ema_fast),
+            "ema_slow": _safe(ema_slow),
+            "ema_long": _safe(ema_long),
+            "ema_slope": _safe(ema_slope),
+            "ema_spread": _safe(ema_spread),
+            "long_spread": _safe(long_spread),
+            "pr_rv20": _safe(rv_pr),
+            "zscore": _safe(zscore),
+            "bbw": _safe(bbw),
+            "donch": _safe(donch),
+            "adx": _safe(adx),
+            "price": _safe(c),
+            "ts": ts_val,
         }
         bus.update_features(sym, itv, out)
         key = (sym, itv)

--- a/ftm2/signal/scoring.py
+++ b/ftm2/signal/scoring.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Dict
+import math
+import os
+
+
+def _env_float(key: str, default: float) -> float:
+    raw = os.getenv(key)
+    if raw in (None, ""):
+        return default
+    try:
+        return float(raw)
+    except Exception:
+        return default
+
+
+W_TREND = _env_float("SC_W_TREND", 0.5)
+W_MR = _env_float("SC_W_MR", 0.3)
+W_BRK = _env_float("SC_W_BRK", 0.2)
+
+
+def _load_thresholds() -> Dict[str, Dict[str, float]]:
+    base = {
+        "UP": {"enter": 0.35, "exit": -0.25},
+        "DOWN": {"enter": 0.35, "exit": -0.25},
+        "FLAT": {"enter": 0.55, "exit": -0.10},
+    }
+    for regime in base:
+        ent = os.getenv(f"SC_{regime}_ENTER")
+        ext = os.getenv(f"SC_{regime}_EXIT")
+        if ent:
+            try:
+                base[regime]["enter"] = float(ent)
+            except Exception:
+                pass
+        if ext:
+            try:
+                base[regime]["exit"] = float(ext)
+            except Exception:
+                pass
+    return base
+
+
+TH = _load_thresholds()
+
+
+def _sigmoid(x: float) -> float:
+    if x >= 0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)
+
+
+def _clip(x: float, low: float, high: float) -> float:
+    if x < low:
+        return low
+    if x > high:
+        return high
+    return x
+
+
+class Forecaster:
+    """Forecast ensemble that blends multi-timeframe features with regime context."""
+
+    def __init__(self, features: Dict[str, Dict[str, dict]], regime_map: Dict[str, dict]):
+        self.features = features
+        self.regime_map = regime_map
+
+    # [ANCHOR:SCORING]
+    def _component_scores(self, f5: dict, f15: dict, f1h: dict, f4h: dict) -> Dict[str, float]:
+        mom = 0.0
+        if f5 and f15:
+            mom = 0.6 * _clip(f15.get("ema_spread", 0.0), -0.01, 0.01)
+            mom += 0.4 * _clip(f5.get("ema_slope", 0.0), -0.01, 0.01)
+            adx = f15.get("adx", 0.0)
+            if adx > 20.0:
+                mom += 0.001 * (adx - 20.0)
+
+        mr = 0.0
+        if f5:
+            mr = -_clip(f5.get("zscore", 0.0), -3.0, 3.0) * 0.15
+
+        brk = 0.0
+        if f15:
+            brk = 0.5 * _clip(f15.get("donch", 0.0), -1.0, 1.0)
+            brk += 0.5 * _clip(f15.get("bbw", 0.0), 0.0, 0.5)
+
+        vol_pen = 0.0
+        if f4h:
+            rv = f4h.get("pr_rv20", f4h.get("rv_pr", 0.5))
+            if rv > 0.85:
+                vol_pen = -0.10
+            elif rv > 0.75:
+                vol_pen = -0.05
+
+        return {"mom": mom, "meanrev": mr, "breakout": brk, "vol": vol_pen}
+
+    def forecast_symbol(self, sym: str, horizon_k: int = 12) -> dict:
+        feats = self.features.get(sym, {})
+        f5 = feats.get("5m", {})
+        f15 = feats.get("15m", {})
+        f1h = feats.get("1h", {})
+        f4h = feats.get("4h", {})
+
+        if not f5 or not f15 or not f4h:
+            return {"symbol": sym, "readiness": "BLOCKED", "reason": "insufficient_features"}
+
+        regime = self.regime_map.get(sym, {"trend": "FLAT", "vol": "LOW"})
+        comp = self._component_scores(f5, f15, f1h, f4h)
+        base = W_TREND * comp["mom"] + W_MR * comp["meanrev"] + W_BRK * comp["breakout"] + comp["vol"]
+        trend = regime.get("trend", "FLAT").upper()
+        if trend == "UP":
+            base += 0.10
+        elif trend == "DOWN":
+            base -= 0.10
+
+        score = base
+        p_up = _sigmoid(3.0 * score)
+
+        th = TH.get(trend, TH["FLAT"])
+        stance = "FLAT"
+        if score >= th["enter"]:
+            stance = "LONG"
+        elif score <= -th["enter"]:
+            stance = "SHORT"
+        elif abs(score) < abs(th["exit"]):
+            stance = "FLAT"
+
+        readiness = "SCOUT"
+        if abs(score) >= 0.25:
+            readiness = "CANDIDATE"
+
+        gates = {
+            "regime_ok": True,
+            "rv_band_ok": f4h.get("pr_rv20", f4h.get("rv_pr", 0.5)) <= 0.95,
+            "risk_ok": True,
+            "cooldown_ok": True,
+            "cooldown_s": 0,
+        }
+
+        explain = {**comp, "regime": (0.10 if trend == "UP" else (-0.10 if trend == "DOWN" else 0.0))}
+
+        return {
+            "symbol": sym,
+            "tf": "5m",
+            "score": round(score, 4),
+            "p_up": round(p_up, 4),
+            "stance": stance,
+            "readiness": readiness,
+            "gates": gates,
+            "horizon_k": horizon_k,
+            "explain": explain,
+            "plan": {
+                "entry": "market",
+                "size_qty_est": None,
+                "notional_est": None,
+                "risk_R": 0.1,
+                "sl": 1.5,
+                "tp_ladder": [1.0, 2.0, 3.0],
+            },
+        }
+
+
+__all__ = ["Forecaster", "TH", "W_TREND", "W_MR", "W_BRK"]
+

--- a/patch.txt
+++ b/patch.txt
@@ -14,6 +14,12 @@
 - feat(streams): StreamManager — 완료봉·시계열 스냅샷 유지 및 계정/마크 동시 반영, 스큐/역전 필터
 - feat(exec): OrderRouter — idem/link_id/쿨다운/슬리피지/재시도 가드 및 reduceOnly 대응
 
+2025-09-30 v0.3.6
+- feat(features): 다중 TF(5m/15m/1h/4h) 파이프라인 + ATR/RV/zscore/ADX/Donchian/BBW
+- feat(regime): 4h 레짐 분류(UP/DOWN/FLAT × HIGH/LOW) + 히스테리시스/라벨링
+- feat(forecast): 4h 레짐 가중 앙상블 → score·P(상승)·stance/readiness·gate 산출
+- feat(report): 디스코드 카드 개편(P(상승)·레짐·계획/보호/쿨다운 섹션)
+
 # M2 이후 릴리스 예시 템플릿(참고용):
 # 2025-09-03 v0.2.0
 # - feat(features): 피처 파이프라인 1차(지표 계산/NaN 처리/퍼센타일 캐시)


### PR DESCRIPTION
## Summary
- extend the feature engine with multi-timeframe metrics (EMA slope/spread, volatility bands, Donchian breakout, ADX) while keeping outputs NaN-safe and env-tunable
- add a lightweight hysteresis-based 4h regime helper and a regime-weighted forecaster that produces scores, probabilities, gates, and readiness metadata
- refresh the analysis brief renderer to surface probability of upside, regime context, plan/protection notes, and trace payloads

## Testing
- python -m compileall ftm2/data/features.py ftm2/signal/regime.py ftm2/signal/scoring.py ftm2/analysis/report.py

------
https://chatgpt.com/codex/tasks/task_e_68db4991f9f8832da8263cee83653dea