### PR TITLE
feat: add hot reload and discord config controls

### DIFF
--- a/ftm2/exchange/binance.py
+++ b/ftm2/exchange/binance.py
@@ -257,6 +257,14 @@ class BinanceClient:
             )
         return out
 
+    # [ANCHOR:SET_LEVERAGE]
+    def set_leverage(self, symbol: str, leverage: int) -> dict:
+        payload = {"symbol": symbol.upper(), "leverage": int(leverage)}
+        resp = self._r("POST", "/fapi/v1/leverage", payload, auth=True)
+        if not resp.ok:
+            raise RuntimeError(f"leverage_set_fail:{resp.code}:{resp.msg}")
+        return resp.data or {}
+
     # ------------------------------------------------------------------
     # Orders
     # ------------------------------------------------------------------

--- a/ftm2/notify/discord.py
+++ b/ftm2/notify/discord.py
@@ -46,3 +46,40 @@ class Alerts:
             f"• ts: <t:{int(time.time())}:T>"
         )
         _post_channel_message(self.chan, msg)
+
+    # [ANCHOR:DISCORD_CONFIG_ALERTS]
+    def config_profile(self, level: int, envs: dict) -> None:
+        keys = [
+            "RISK_TARGET_PCT",
+            "EXEC_SLIPPAGE_BPS",
+            "REENTER_COOLDOWN_S",
+            "IK_TWIST_GUARD",
+            "IK_THICK_PCT",
+            "W_IMK",
+            "SC_W_TREND",
+            "SC_W_MR",
+            "CORR_CAP_PER_SIDE",
+            "DAILY_MAX_LOSS_PCT",
+            "REGIME_ALIGN_MODE",
+        ]
+        brief = ", ".join([f"{k}={envs.get(k)}" for k in keys if k in envs])
+        _post_channel_message(
+            self.chan,
+            f"**[CONFIG] Risk profile={level} 적용**\n{brief}",
+        )
+
+    def config_leverage(
+        self, symbol: str, value: int, ok: bool, err: str | None = None
+    ) -> None:
+        if ok:
+            _post_channel_message(
+                self.chan, f"**[CONFIG] Leverage {symbol} → {value}x (OK)**"
+            )
+        else:
+            _post_channel_message(
+                self.chan,
+                f"**[CONFIG] Leverage {symbol} → {value}x (FAIL)**\n`{err}`",
+            )
+
+    def config_announce(self, line: str) -> None:
+        _post_channel_message(self.chan, f"[CONFIG] {line}")

--- a/ftm2/ops/hotreload.py
+++ b/ftm2/ops/hotreload.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+from typing import Callable, Dict, Tuple
+
+log = logging.getLogger("ftm2.hotreload")
+
+# 엔진 모듈과 키 매핑 (존재하면 수정)
+_KEYMAP: Dict[str, Tuple[str, str]] = {
+    "RISK_TARGET_PCT": ("ftm2.risk.engine", "RISK_TARGET_PCT"),
+    "EXEC_SLIPPAGE_BPS": ("ftm2.trade.router", "EXEC_SLIPPAGE_BPS"),
+    "REENTER_COOLDOWN_S": ("ftm2.risk.gates", "REENTER_COOLDOWN_S"),
+    "IK_TWIST_GUARD": ("ftm2.risk.gates", "IK_TWIST_GUARD"),
+    "IK_THICK_PCT": ("ftm2.risk.gates", "IK_THICK_PCT"),
+    "SC_W_TREND": ("ftm2.signal.scoring", "W_TREND"),
+    "SC_W_MR": ("ftm2.signal.scoring", "W_MR"),
+    "W_IMK": ("ftm2.signal.scoring", "W_IMK"),
+    "CORR_CAP_PER_SIDE": ("ftm2.risk.engine", "CORR_CAP_PER_SIDE"),
+    "DAILY_MAX_LOSS_PCT": ("ftm2.risk.engine", "DAILY_MAX_LOSS_PCT"),
+    "REGIME_ALIGN_MODE": ("ftm2.risk.gates", "REGIME_ALIGN_MODE"),
+    "IK_TENKAN": ("ftm2.data.features_ichimoku", "IK_TENKAN"),
+    "IK_KIJUN": ("ftm2.data.features_ichimoku", "IK_KIJUN"),
+    "IK_SEN": ("ftm2.data.features_ichimoku", "IK_SEN"),
+}
+
+
+class HotReloader:
+    """env_key/value를 각 모듈 상수와 os.environ에 반영"""
+
+    def __init__(self, on_announce: Callable[[str], None] | None = None) -> None:
+        self.on_announce = on_announce
+
+    # [ANCHOR:HOT_RELOAD]
+    def apply(self, env_key: str, new_value: str) -> bool:
+        os.environ[env_key] = str(new_value)
+        modinfo = _KEYMAP.get(env_key)
+        if modinfo:
+            modname, attr = modinfo
+            try:
+                mod = importlib.import_module(modname)
+                val: object = self._auto_cast(new_value)
+                setattr(mod, attr, val)
+                log.info("HOTRELOAD %s.%s = %s", modname, attr, val)
+            except Exception as exc:  # pragma: no cover - logging side effect only
+                log.warning("HOTRELOAD.FAIL %s %s", env_key, exc)
+                return False
+        if callable(self.on_announce):
+            self.on_announce(f"{env_key} → {new_value}")
+        return True
+
+    def _auto_cast(self, v: str):
+        s = str(v).strip().lower()
+        if s in ("true", "false"):
+            return s == "true"
+        try:
+            if "." in s:
+                return float(s)
+            return int(s)
+        except Exception:
+            return v

--- a/ftm2/panel/discord_controls.py
+++ b/ftm2/panel/discord_controls.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
 from typing import Callable, Dict
+import logging
 import os
 import sqlite3
 import time
+
+try:
+    import discord  # discord.py 2.x
+    from discord import app_commands
+except Exception:  # pragma: no cover - optional dependency
+    discord = None  # type: ignore
+
+from ftm2.exchange.binance import BinanceClient
+from ftm2.notify.discord import Alerts
+from ftm2.ops.hotreload import HotReloader
+from ftm2.risk.profile import RiskProfileApplier
+
+log = logging.getLogger("ftm2.panel")
 
 
 class ConfigStore:
@@ -88,3 +102,179 @@ class PanelTuner:
             current = float(self.store.get(f"env.{env_key}", os.getenv(env_key, "0")))
             return self._apply_set(key, current + delta)
         return {"ok": False, "error": "unknown_cmd"}
+
+
+class _KV:
+    def __init__(self, store):
+        self.store = store
+
+    def get(self, k, d=None):
+        return self.store.get(k, d)
+
+    def set(self, k, v):
+        self.store.set(k, v)
+
+
+class PanelApp:
+    """Discord 봇 등록기. discord.py가 설치되어 있지 않으면 skip."""
+
+    # [ANCHOR:PANEL_HANDLERS]
+    def __init__(self, store, alerts: Alerts, bx: BinanceClient):
+        self.alerts = alerts
+        self.store = _KV(store)
+        self.bx = bx
+        self.hot = HotReloader(on_announce=lambda msg: self.alerts.config_announce(msg)).apply
+        self.prof = RiskProfileApplier(store, self.hot)
+        self.bot = None
+        if discord:
+            intents = discord.Intents.default()
+            self.bot = discord.Client(intents=intents)
+            self.tree = app_commands.CommandTree(self.bot)
+            self._register_commands()
+            self.bot.event(self.on_ready)
+
+    async def on_ready(self):
+        try:
+            await self.tree.sync()
+            log.info("Discord commands synced")
+        except Exception as exc:  # pragma: no cover - logging only
+            log.warning("Discord sync fail %s", exc)
+
+    def _register_commands(self):
+        if not discord:
+            return
+
+        @self.tree.command(name="risk", description="공격성(1~10) 설정")
+        @app_commands.describe(level="1~10")
+        async def risk_cmd(inter: discord.Interaction, level: int):
+            out = self.prof.apply_level(level)
+            msg = self._format_profile_msg(level, out)
+            self.alerts.config_profile(level, out)
+            await inter.response.send_message(msg, ephemeral=True)
+
+        @self.tree.command(name="lev", description="심볼별 레버리지 설정")
+        @app_commands.describe(symbol="예: BTCUSDT", value="1~125")
+        async def lev_cmd(inter: discord.Interaction, symbol: str, value: int):
+            sym = symbol.upper()
+            try:
+                self.bx.set_leverage(sym, int(value))
+                self.store.set(f"lev.{sym}", str(int(value)))
+                self.alerts.config_leverage(sym, int(value), ok=True)
+                await inter.response.send_message(
+                    f"Leverage {sym} → {int(value)}x (OK)", ephemeral=True
+                )
+            except Exception as exc:
+                self.alerts.config_leverage(sym, int(value), ok=False, err=str(exc))
+                await inter.response.send_message(
+                    f"❌ leverage set fail: {exc}", ephemeral=True
+                )
+
+        @self.tree.command(name="panel", description="리스크/레버리지 버튼 패널 표시")
+        @app_commands.describe(symbol="레버리지 조절할 심볼")
+        async def panel_cmd(inter: discord.Interaction, symbol: str):
+            await inter.response.send_message(
+                content=self._panel_text(symbol),
+                view=self._make_view(symbol),
+                ephemeral=True,
+            )
+
+    def _make_view(self, symbol: str):
+        if not discord:
+            return None
+
+        sym = symbol.upper()
+
+        class PanelView(discord.ui.View):
+            def __init__(self, outer: PanelApp, sym: str):
+                super().__init__(timeout=120)
+                self.outer = outer
+                self.sym = sym
+
+            @discord.ui.button(label="Risk −", style=discord.ButtonStyle.secondary, custom_id="risk:-")
+            async def risk_minus(self, inter: discord.Interaction, _btn: discord.ui.Button):
+                cur = int(self.outer.store.get("profile.level", "5") or "5")
+                new = max(1, cur - 1)
+                out = self.outer.prof.apply_level(new)
+                self.outer.alerts.config_profile(new, out)
+                await inter.response.edit_message(
+                    content=self.outer._panel_text(self.sym), view=self
+                )
+
+            @discord.ui.button(label="Risk +", style=discord.ButtonStyle.primary, custom_id="risk:+")
+            async def risk_plus(self, inter: discord.Interaction, _btn: discord.ui.Button):
+                cur = int(self.outer.store.get("profile.level", "5") or "5")
+                new = min(10, cur + 1)
+                out = self.outer.prof.apply_level(new)
+                self.outer.alerts.config_profile(new, out)
+                await inter.response.edit_message(
+                    content=self.outer._panel_text(self.sym), view=self
+                )
+
+            @discord.ui.button(label="Lev −", style=discord.ButtonStyle.secondary, custom_id="lev:-")
+            async def lev_minus(self, inter: discord.Interaction, _btn: discord.ui.Button):
+                cur = int(self.outer.store.get(f"lev.{self.sym}", "5") or "5")
+                new = max(1, cur - 1)
+                try:
+                    self.outer.bx.set_leverage(self.sym, new)
+                    self.outer.store.set(f"lev.{self.sym}", str(new))
+                    self.outer.alerts.config_leverage(self.sym, new, ok=True)
+                except Exception as exc:
+                    self.outer.alerts.config_leverage(
+                        self.sym, new, ok=False, err=str(exc)
+                    )
+                await inter.response.edit_message(
+                    content=self.outer._panel_text(self.sym), view=self
+                )
+
+            @discord.ui.button(label="Lev +", style=discord.ButtonStyle.primary, custom_id="lev:+")
+            async def lev_plus(self, inter: discord.Interaction, _btn: discord.ui.Button):
+                cur = int(self.outer.store.get(f"lev.{self.sym}", "5") or "5")
+                new = min(125, cur + 1)
+                try:
+                    self.outer.bx.set_leverage(self.sym, new)
+                    self.outer.store.set(f"lev.{self.sym}", str(new))
+                    self.outer.alerts.config_leverage(self.sym, new, ok=True)
+                except Exception as exc:
+                    self.outer.alerts.config_leverage(
+                        self.sym, new, ok=False, err=str(exc)
+                    )
+                await inter.response.edit_message(
+                    content=self.outer._panel_text(self.sym), view=self
+                )
+
+        return PanelView(self, sym)
+
+    def _panel_text(self, symbol: str) -> str:
+        sym = symbol.upper()
+        lvl = int(self.store.get("profile.level", "5") or "5")
+        lev = int(self.store.get(f"lev.{sym}", "5") or "5")
+        return (
+            "**Risk/Leverage Panel**\n"
+            f"• Symbol: `{sym}`\n"
+            f"• Risk Level: `{lvl}` (1=보수 ←→ 10=공격)\n"
+            f"• Leverage: `{lev}x`\n"
+            "버튼으로 값 변경 시 DB 저장→핫리로드→Alerts 공지"
+        )
+
+    def _format_profile_msg(self, level: int, envs: Dict[str, str]) -> str:
+        keys = [
+            "RISK_TARGET_PCT",
+            "EXEC_SLIPPAGE_BPS",
+            "REENTER_COOLDOWN_S",
+            "IK_TWIST_GUARD",
+            "IK_THICK_PCT",
+            "W_IMK",
+            "SC_W_TREND",
+            "SC_W_MR",
+            "CORR_CAP_PER_SIDE",
+            "DAILY_MAX_LOSS_PCT",
+            "REGIME_ALIGN_MODE",
+        ]
+        parts = [f"{k}={envs.get(k, '-')}" for k in keys]
+        return f"Risk profile={level} 적용\n" + " • " + "\n • ".join(parts)
+
+    def run(self, token: str) -> None:
+        if not discord:
+            log.warning("discord.py 미설치 — 패널 비활성")
+            return
+        self.bot.run(token)

--- a/ftm2/risk/profile.py
+++ b/ftm2/risk/profile.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+
+# [ANCHOR:PROFILE_APPLIER]
+class RiskProfileApplier:
+    def __init__(self, store, hot_reload_cb: Callable[[str, str], None]):
+        self.store = store
+        self.hot = hot_reload_cb
+
+    def apply_level(self, level: int) -> Dict[str, str]:
+        lv = max(1, min(10, int(level)))
+        a = (lv - 1) / 9.0  # α ∈ [0,1]
+
+        out: Dict[str, str] = {}
+
+        def setk(k: str, v) -> None:
+            key = f"env.{k}"
+            val = str(v)
+            self.store.set(key, val)
+            self.hot(k, val)
+            out[k] = val
+
+        setk("RISK_TARGET_PCT", round(0.10 + 0.25 * a, 4))
+        setk("DAILY_MAX_LOSS_PCT", round(0.015 + 0.02 * a, 4))
+        setk("EXEC_SLIPPAGE_BPS", round(3 + 7 * a, 2))
+        setk("REENTER_COOLDOWN_S", int(round(180 - 150 * a)))
+        setk("IK_TWIST_GUARD", int(round(10 - 7 * a)))
+        setk("IK_THICK_PCT", round(0.85 + 0.10 * a, 3))
+        setk("CORR_CAP_PER_SIDE", round(0.80 - 0.20 * a, 2))
+        setk("SC_W_TREND", round(0.45 + 0.10 * a, 3))
+        setk("SC_W_MR", round(0.35 - 0.10 * a, 3))
+        setk("W_IMK", round(0.30 + 0.10 * a, 3))
+        setk("REGIME_ALIGN_MODE", "strict" if a < 0.2 else "soft")
+
+        self.store.set("profile.level", str(lv))
+        return out

--- a/ftm2/run_panel_bot.py
+++ b/ftm2/run_panel_bot.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from ftm2.exchange.binance import BinanceClient
+from ftm2.notify.discord import Alerts
+from ftm2.panel.discord_controls import ConfigStore, PanelApp
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    token = os.getenv("DISCORD_BOT_TOKEN", "")
+    if not token:
+        raise SystemExit("DISCORD_BOT_TOKEN 필수")
+
+    store = ConfigStore("ftm2.sqlite3")
+    alerts = Alerts()
+    bx = BinanceClient(mode=os.getenv("MODE", "testnet"))
+
+    app = PanelApp(store, alerts, bx)
+    app.run(token)
+
+
+if __name__ == "__main__":
+    main()

--- a/patch.txt
+++ b/patch.txt
@@ -9,6 +9,13 @@
 # YYYY-MM-DD vX.Y.Z
 # - feat(scope): 한글 요약 …
 #
+2025-10-01 v0.4.4
+- feat(ops): HotReload 콜백 — env.* 변경 즉시 엔진 반영(+Alerts 공지)
+- feat(risk): RiskProfileApplier — 공격성(1~10) → 파라미터 맵핑 일괄 적용(DB 저장·핫리로드)
+- feat(exchange): Binance 레버리지 API set_leverage()
+- feat(panel): /risk /lev 슬래시 + 버튼 패널(리스크±, 레버리지±) — DB 저장·핫리로드·Alerts 공지
+- feat(alerts): CONFIG 공지 포맷 추가(profile/leverage/announce)
+
 2025-09-30 v0.4.0
 - feat(risk): RiskEngine v1.5 — ATR/R-unit/상관캡/데일리컷/쿨다운
 - feat(gates): GateKeeper — 레짐/구름일관성/두께/트위스트/포지션충돌/재진입쿨다운


### PR DESCRIPTION
## Summary
- add a HotReloader utility to push env changes into runtime modules and announce updates
- implement a risk profile applier plus Discord slash/button handlers that drive alerts and leverage updates
- expose Binance futures leverage setter, alerts helpers, a panel runner script, and log the release in patch.txt

## Testing
- python -m compileall ftm2/ops/hotreload.py ftm2/risk/profile.py ftm2/panel/discord_controls.py ftm2/notify/discord.py ftm2/run_panel_bot.py


------
https://chatgpt.com/codex/tasks/task_e_68db66649e08832db72fd6f35b82e66e