### PR TITLE
feat: add DB idem guard and per-symbol slippage overrides

### DIFF
--- a/ftm2/db/core.py
+++ b/ftm2/db/core.py
@@ -1,41 +1,145 @@
+from __future__ import annotations
+
+import logging
 import os
 import sqlite3
+import threading
+import time
+from typing import Optional
 
-_conn: sqlite3.Connection | None = None
+log = logging.getLogger("ftm2.db.core")
 
-
-def get_conn(db_path: str | None = None) -> sqlite3.Connection:
-    global _conn
-    if _conn is None:
-        path = db_path or os.getenv("DB_PATH", "./runtime/trader.db")
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        _conn = sqlite3.connect(path, check_same_thread=False)
-        _conn.row_factory = sqlite3.Row
-        _conn.execute("PRAGMA journal_mode=WAL;")
-        _conn.execute("PRAGMA synchronous=NORMAL;")
-    return _conn
+_DB_LOCK = threading.Lock()
+_CONN: sqlite3.Connection | None = None
+_DB_PATH: str | None = None
 
 
-def _col_exists(conn: sqlite3.Connection, table: str, col: str) -> bool:
-    cur = conn.execute(f"PRAGMA table_info({table})")
-    return any(row[1] == col for row in cur.fetchall())
+def get_conn(path: Optional[str] = None) -> sqlite3.Connection:
+    """Return a shared SQLite connection ensuring schema availability."""
+
+    global _CONN, _DB_PATH
+
+    resolved = path or os.getenv("DB_PATH", "ftm2.sqlite3")
+    with _DB_LOCK:
+        if _CONN is None or _DB_PATH != resolved:
+            if _CONN is not None:
+                try:
+                    _CONN.close()
+                except Exception:  # pragma: no cover - best effort close
+                    pass
+            os.makedirs(os.path.dirname(resolved) or ".", exist_ok=True)
+            _CONN = sqlite3.connect(
+                resolved,
+                timeout=10.0,
+                check_same_thread=False,
+                isolation_level=None,  # autocommit
+            )
+            _CONN.row_factory = sqlite3.Row
+            _CONN.execute("PRAGMA journal_mode=WAL;")
+            _CONN.execute("PRAGMA synchronous=NORMAL;")
+            _ensure_schema(_CONN)
+            _DB_PATH = resolved
+        return _CONN
 
 
-def init_db(db_path: str = "./runtime/trader.db") -> sqlite3.Connection:
-    conn = get_conn(db_path)
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    # config key-value storage
     conn.execute(
         """
-        CREATE TABLE IF NOT EXISTS config (
-            key TEXT PRIMARY KEY
-            -- val column is added below if missing
-        )
+        CREATE TABLE IF NOT EXISTS config(
+          key TEXT PRIMARY KEY,
+          val TEXT,
+          ts INTEGER
+        );
         """
     )
-    if not _col_exists(conn, "config", "val"):
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(config)")]
+    if "val" not in cols:
         conn.execute("ALTER TABLE config ADD COLUMN val TEXT")
+    if "ts" not in cols:
+        conn.execute("ALTER TABLE config ADD COLUMN ts INTEGER")
+    # migrate legacy columns if present
+    if "value" in cols:
+        conn.execute("UPDATE config SET val = value WHERE val IS NULL")
+    if "v" in cols:
+        conn.execute("UPDATE config SET val = v WHERE val IS NULL")
+
+    # idem key registry (atomic reservations)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS idem_keys(
+          key TEXT PRIMARY KEY,
+          symbol TEXT,
+          side TEXT,
+          anchor_tf TEXT,
+          bar_ts INTEGER,
+          created_ts INTEGER,
+          expires_ts INTEGER
+        );
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_idem_exp ON idem_keys(expires_ts);"
+    )
+
+
+def config_set(k: str, v: str) -> None:
+    conn = get_conn()
+    ts = int(time.time())
+    with _DB_LOCK:
+        conn.execute(
+            """
+            INSERT INTO config(key, val, ts) VALUES(?,?,?)
+            ON CONFLICT(key) DO UPDATE SET val=excluded.val, ts=excluded.ts
+            """,
+            (k, v, ts),
+        )
+
+
+def config_get(k: str, default=None):
+    conn = get_conn()
+    with _DB_LOCK:
+        cur = conn.execute("SELECT val FROM config WHERE key=?", (k,))
+        row = cur.fetchone()
+    return row[0] if row and row[0] is not None else default
+
+
+def idem_reserve(
+    key: str,
+    symbol: str,
+    side: str,
+    anchor_tf: str,
+    bar_ts: int,
+    ttl_ms: int,
+) -> bool:
+    """Try to reserve an idempotency key for the specified bar context."""
+
+    now_ms = int(time.time() * 1000)
+    expires_ts = int(bar_ts + max(ttl_ms, 0))
+    conn = get_conn()
+
+    with _DB_LOCK:
         try:
-            conn.execute("UPDATE config SET val = value WHERE val IS NULL")
-        except sqlite3.OperationalError:
-            pass
-        conn.commit()
-    return conn
+            conn.execute("DELETE FROM idem_keys WHERE expires_ts < ?", (now_ms,))
+            conn.execute(
+                """
+                INSERT INTO idem_keys(
+                  key, symbol, side, anchor_tf, bar_ts, created_ts, expires_ts
+                ) VALUES(?,?,?,?,?,?,?)
+                """,
+                (key, symbol, side, anchor_tf, bar_ts, now_ms, expires_ts),
+            )
+            return True
+        except sqlite3.IntegrityError:
+            log.info("DB.IDEM.RESERVE.CONFLICT key=%s", key)
+            return False
+        except Exception:
+            log.exception("DB.IDEM.RESERVE.ERROR key=%s", key)
+            return False
+
+
+def init_db(db_path: Optional[str] = None) -> sqlite3.Connection:
+    """Backwards compatible helper returning the shared connection."""
+
+    return get_conn(db_path)
+

--- a/ftm2/trade/idem.py
+++ b/ftm2/trade/idem.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+_TF2MS = {
+    "1m": 60_000,
+    "3m": 180_000,
+    "5m": 300_000,
+    "15m": 900_000,
+    "30m": 1_800_000,
+    "1h": 3_600_000,
+    "4h": 14_400_000,
+    "1d": 86_400_000,
+}
+
+
+def tf_ms(tf: str) -> int:
+    """Return timeframe duration in milliseconds."""
+
+    return _TF2MS.get(tf, 300_000)
+
+
+def make_idem_key(symbol: str, stance: str, anchor_tf: str, bar_ts: int) -> str:
+    """Create a normalized idempotency key."""
+
+    return f"{symbol.upper()}:{anchor_tf}:{int(bar_ts)}:{stance.upper()}"
+

--- a/patch.txt
+++ b/patch.txt
@@ -9,6 +9,11 @@
 # YYYY-MM-DD vX.Y.Z
 # - feat(scope): 한글 요약 …
 #
+2025-10-01 v0.4.6
+- feat(db): config KV 확장 + idem_keys 테이블(중복 주문 방지, 원자적 예약)
+- feat(exec): 라우터 주문 전 DB 기반 idem 예약 + 심볼별 슬리피지 허용(bps) 우선순위(DB per-symbol > DB wildcard > ENV)
+- feat(panel): /slip 심볼별 슬리피지 bps 설정 커맨드(Alerts 공지)
+
 2025-10-01 v0.4.4
 - feat(ops): HotReload 콜백 — env.* 변경 즉시 엔진 반영(+Alerts 공지)
 - feat(risk): RiskProfileApplier — 공격성(1~10) → 파라미터 맵핑 일괄 적용(DB 저장·핫리로드)


### PR DESCRIPTION
## Summary
- extend the SQLite core to share a WAL connection, expose config helpers, and persist idempotency reservations
- add timeframe utilities and update the order router/executor to enforce DB-backed idem guards with per-symbol slippage limits
- wire Discord panel controls to the shared config store and provide a /slip command plus slippage display updates

## Testing
- `python -m compileall ftm2`


------
https://chatgpt.com/codex/tasks/task_e_68db756a1820832dabce8d4a6125f9a5