### PR TITLE
feat: add persistent order tracking

### DIFF
--- a/database_manager.py
+++ b/database_manager.py
@@ -1,0 +1,167 @@
+"""Database management utilities for the trading bot.
+
+This module encapsulates all SQLite interactions to provide a
+single place to create and update order records.  It is designed to
+be imported by the Discord bot main module when recording order
+intentions and syncing state with Binance responses.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+DB_NAME = "trading_bot.db"
+
+
+def get_db_connection() -> sqlite3.Connection:
+    """Create and return a new database connection."""
+
+    conn = sqlite3.connect(DB_NAME)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db() -> None:
+    """Initialise the database and ensure the ``orders`` table exists."""
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            client_order_id TEXT NOT NULL UNIQUE,
+            binance_order_id INTEGER,
+            symbol TEXT NOT NULL,
+            order_type TEXT NOT NULL,
+            side TEXT NOT NULL,
+            quantity REAL NOT NULL,
+            price REAL,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    print("데이터베이스가 성공적으로 초기화되었습니다.")
+
+
+def create_order_record(order_params: Dict[str, Any]) -> Tuple[int, str]:
+    """Persist a new order intent with a ``CREATED`` status."""
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    now = datetime.utcnow().isoformat()
+    client_order_id = f"bot_{int(datetime.utcnow().timestamp() * 1000)}"
+
+    cursor.execute(
+        """
+        INSERT INTO orders (
+            client_order_id,
+            symbol,
+            order_type,
+            side,
+            quantity,
+            price,
+            status,
+            created_at,
+            updated_at
+        )
+        VALUES (?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            client_order_id,
+            order_params.get("symbol"),
+            order_params.get("type"),
+            order_params.get("side"),
+            order_params.get("quantity"),
+            order_params.get("price"),
+            "CREATED",
+            now,
+            now,
+        ),
+    )
+
+    local_order_id = cursor.lastrowid
+    conn.commit()
+    conn.close()
+
+    print(
+        "주문 기록 생성됨 (ID: %s): %s %s %s"
+        % (
+            local_order_id,
+            order_params.get("symbol"),
+            order_params.get("side"),
+            order_params.get("quantity"),
+        )
+    )
+    return local_order_id, client_order_id
+
+
+def update_order_from_binance(local_order_id: int, binance_response: Dict[str, Any]) -> None:
+    """Update an order using the Binance API response."""
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    now = datetime.utcnow().isoformat()
+
+    cursor.execute(
+        """
+        UPDATE orders
+        SET binance_order_id = ?, status = ?, updated_at = ?
+        WHERE id = ?
+        """,
+        (
+            binance_response.get("orderId"),
+            binance_response.get("status"),
+            now,
+            local_order_id,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    print(
+        "주문 상태 업데이트됨 (ID: %s): 상태 -> %s"
+        % (local_order_id, binance_response.get("status"))
+    )
+
+
+def update_order_status(local_order_id: int, status: str) -> None:
+    """Directly update an order status (e.g. ``REJECTED``)."""
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    now = datetime.utcnow().isoformat()
+
+    cursor.execute(
+        "UPDATE orders SET status = ?, updated_at = ? WHERE id = ?",
+        (status, now, local_order_id),
+    )
+    conn.commit()
+    conn.close()
+    print(f"주문 상태 업데이트됨 (ID: {local_order_id}): 상태 -> {status}")
+
+
+def get_unsettled_orders() -> List[Dict[str, Any]]:
+    """Return all orders that have not reached a final state."""
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    final_statuses = ("FILLED", "CANCELED", "REJECTED", "EXPIRED")
+    query = f"SELECT * FROM orders WHERE status NOT IN {final_statuses}"
+
+    cursor.execute(query)
+    orders = [dict(row) for row in cursor.fetchall()]
+    conn.close()
+
+    print(f"미체결 주문 {len(orders)}건 조회됨.")
+    return orders
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,151 @@
+"""Discord trading bot entry point with persistent order tracking."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import discord
+from binance.client import Client
+from binance.exceptions import BinanceAPIException
+from discord.ext import commands
+from dotenv import load_dotenv
+
+import database_manager as db
+
+
+load_dotenv()
+
+DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+BINANCE_API_KEY = os.getenv("BINANCE_API_KEY")
+BINANCE_API_SECRET = os.getenv("BINANCE_API_SECRET")
+IS_TESTNET = os.getenv("IS_TESTNET", "true").lower() == "true"
+
+intents = discord.Intents.default()
+intents.message_content = True
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+
+try:
+    client = Client(BINANCE_API_KEY, BINANCE_API_SECRET, testnet=IS_TESTNET)
+    client.futures_ping()
+    print(f"바이낸스 연결 성공. (환경: {'테스트넷' if IS_TESTNET else '실거래'})")
+except Exception as exc:  # pragma: no cover - network interaction
+    print(f"바이낸스 연결 실패: {exc}")
+    raise SystemExit(1)
+
+
+async def sync_orders_on_startup() -> None:
+    """Synchronise local orders with Binance on bot startup."""
+
+    print("시작 시 주문 상태 동기화를 시작합니다...")
+    unsettled_orders = db.get_unsettled_orders()
+
+    if not unsettled_orders:
+        print("동기화할 미체결 주문이 없습니다.")
+        return
+
+    for order in unsettled_orders:
+        try:
+            if order["binance_order_id"]:
+                server_order = client.futures_get_order(
+                    symbol=order["symbol"],
+                    orderId=order["binance_order_id"],
+                )
+            else:
+                server_order = client.futures_get_order(
+                    symbol=order["symbol"],
+                    origClientOrderId=order["client_order_id"],
+                )
+
+            if order["status"] != server_order["status"]:
+                print(
+                    "상태 불일치 발견 (ID: {id}). 로컬: {local}, 서버: {server}. 동기화합니다.".format(
+                        id=order["id"],
+                        local=order["status"],
+                        server=server_order["status"],
+                    )
+                )
+                db.update_order_from_binance(order["id"], server_order)
+
+        except BinanceAPIException as exc:
+            if exc.code == -2013:
+                print(
+                    f"주문 ID {order['id']}를 서버에서 찾을 수 없습니다. 상태를 'CANCELED'로 간주합니다."
+                )
+                db.update_order_status(order["id"], "CANCELED")
+            else:
+                print(f"주문 동기화 중 오류 발생 (ID: {order['id']}): {exc}")
+        except Exception as exc:  # pragma: no cover - defensive logging
+            print(f"알 수 없는 오류로 주문 동기화 실패 (ID: {order['id']}): {exc}")
+
+        await asyncio.sleep(0.2)
+
+    print("주문 상태 동기화가 완료되었습니다.")
+
+
+@bot.event
+async def on_ready() -> None:
+    print(f"{bot.user.name} 봇이 준비되었습니다.")
+    db.init_db()
+    await sync_orders_on_startup()
+
+
+@bot.command(name="주문")
+@commands.is_owner()
+async def place_order(
+    ctx: commands.Context, symbol: str, side: str, quantity: float, price: float | None = None
+) -> None:
+    """Place a futures order via Binance."""
+
+    side = side.upper()
+    if side not in {"BUY", "SELL"}:
+        await ctx.send("잘못된 주문 방향입니다. 'BUY' 또는 'SELL'을 사용해주세요.")
+        return
+
+    order_type = "LIMIT" if price is not None else "MARKET"
+
+    order_params = {
+        "symbol": symbol.upper(),
+        "side": side,
+        "type": order_type,
+        "quantity": quantity,
+    }
+
+    if order_type == "LIMIT":
+        order_params["price"] = price
+        order_params["timeInForce"] = "GTC"
+
+    local_order_id, client_order_id = db.create_order_record(order_params)
+    await ctx.send(
+        f"주문 기록 생성됨 (로컬 ID: {local_order_id}). 바이낸스에 전송을 시도합니다..."
+    )
+
+    try:
+        binance_order = client.futures_create_order(
+            newClientOrderId=client_order_id,
+            **order_params,
+        )
+
+        db.update_order_from_binance(local_order_id, binance_order)
+        await ctx.send(
+            "✅ 주문 성공!\n"
+            f"심볼: {binance_order['symbol']}\n"
+            f"바이낸스 ID: {binance_order['orderId']}\n"
+            f"상태: {binance_order['status']}"
+        )
+
+    except BinanceAPIException as exc:
+        db.update_order_status(local_order_id, "REJECTED")
+        await ctx.send(f"❌ 주문 실패 (API 오류): {exc}")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        db.update_order_status(local_order_id, "REJECTED")
+        await ctx.send(f"❌ 주문 실패 (알 수 없는 오류): {exc}")
+
+
+if __name__ == "__main__":
+    if not DISCORD_BOT_TOKEN or not BINANCE_API_KEY or not BINANCE_API_SECRET:
+        print("오류:.env 파일에 DISCORD_BOT_TOKEN, BINANCE_API_KEY, BINANCE_API_SECRET을 설정해야 합니다.")
+    else:
+        bot.run(DISCORD_BOT_TOKEN)
+


### PR DESCRIPTION
## Summary
- add a database manager module to persist and query order state
- refactor the Discord trading bot entry point to initialise and sync orders using the database

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db841a9bf4832db45ba287a51a7447